### PR TITLE
Prevent file-patching to Empty Arma Folder

### DIFF
--- a/src/utilities/filepatching.rs
+++ b/src/utilities/filepatching.rs
@@ -51,6 +51,7 @@ impl Command for FilePatching {
         let mut root = steam_path.clone();
         root.push(ARMA3);
         if root.exists() {
+            root.pop();
             Self::create_link(root, &p)?;
             Ok(())
         } else {

--- a/src/utilities/filepatching.rs
+++ b/src/utilities/filepatching.rs
@@ -37,7 +37,7 @@ impl Command for FilePatching {
 
     fn run(&self, _: &clap::ArgMatches, p: Project) -> Result<(), HEMTTError> {
         // Find Steam directory
-        const ARMA3: &str = "steamapps\\common\\Arma 3";
+        const ARMA3: &str = "steamapps\\common\\Arma 3\\arma3.exe";
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
         let binarize = hkcu.open_subkey("Software\\Valve\\Steam")?;
         let steam_path: String = binarize.get_value("SteamPath")?;

--- a/src/utilities/filepatching.rs
+++ b/src/utilities/filepatching.rs
@@ -68,6 +68,7 @@ impl Command for FilePatching {
                 let mut folder = PathBuf::from(cap.get(2).unwrap().as_str());
                 folder.push(ARMA3);
                 if folder.exists() {
+                    folder.pop();
                     Self::create_link(folder, &p)?;
                     return Ok(());
                 }


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes a Issue when a Empty Folder called Arma 3 is in a Steam Library folder

Sometimes when Steam moves Installation folders a Empty folder persists and does not get deleted. HEMTT used the first Arma 3 Folder it could find even when it was empty.

When searching for the Executable instead to be sure it is the Arma 3 installation