### PR TITLE
Added unoffical download link and instruktions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ HEMTT is available for Linux and Windows via [GitHub Releases](https://github.co
 - Most Windows users will want to use `x86_64-pc-windows-msvc`
 - Most Linux users will want to use `x86_64-unknown-linux-gnu`
 
+### Other install methods
+##### Via Scoop (unofficial) - Windows
+[Scoop](https://scoop.sh/) users can download and install the latest version release by installing the `hemtt` package:
+```
+scoop bucket add Arma3Tools https://github.com/ColdEvul/arma3-scoop-bucket.git
+scoop install hemtt
+```
+To update HEMTT using Scoop, run the following:
+```
+scoop update hemtt
+```
+If you have any issues when installing/updating the package report the same on the [bucket issues page](https://github.com/ColdEvul/arma3-scoop-bucket/issues).
 
 ## Contributing
 


### PR DESCRIPTION
**When merged this pull request will:**
- Added unoffical download link and instruktions for a windows package manager


Exsample usage:
```powershell
~ PS> scoop bucket add Arma3Tools https://github.com/ColdEvul/arma3-scoop-bucket.git
Checking repo... ok
~ PS> scoop install hemtt
Installing 'hemtt' (0.7.6) [64bit]
hemtt-v0.7.6-x86_64-pc-windows-msvc.zip (8.1 MB) [============================================================] 100%
Checking hash of hemtt-v0.7.6-x86_64-pc-windows-msvc.zip ... ok.
Extracting hemtt-v0.7.6-x86_64-pc-windows-msvc.zip ... done.
Linking ~\scoop\apps\hemtt\current => ~\scoop\apps\hemtt\0.7.6
Creating shim for 'hemtt'.
'hemtt' (0.7.6) was installed successfully!
```