### PR TITLE
Fix sqf preprocessor comment edge case

### DIFF
--- a/libs/preprocessor/src/lib.rs
+++ b/libs/preprocessor/src/lib.rs
@@ -90,10 +90,11 @@ where
                 tokenstream.next();
             }
             Symbol::Slash => {
-                if let Some(next) = tokenstream.peek_forward(1) {
-                    if next.symbol() == &Symbol::Slash {
-                        whitespace::skip_comment(tokenstream);
-                    }
+                if matches!(
+                    tokenstream.peek_forward(1).map(Token::symbol),
+                    Some(Symbol::Slash)
+                ) {
+                    whitespace::skip_comment(tokenstream);
                 } else {
                     tokenstream.move_cursor_back().unwrap();
                     if context.ifstates().reading() {
@@ -706,10 +707,11 @@ where
                 )?);
             }
             Symbol::Slash => {
-                if let Some(next) = tokenstream.peek_forward(1) {
-                    if next.symbol() == &Symbol::Slash {
-                        whitespace::skip_comment(tokenstream);
-                    }
+                if matches!(
+                    tokenstream.peek_forward(1).map(Token::symbol),
+                    Some(Symbol::Slash)
+                ) {
+                    whitespace::skip_comment(tokenstream);
                 } else {
                     tokenstream.move_cursor_back().unwrap();
                     output.push(tokenstream.next().unwrap());

--- a/libs/preprocessor/tests/bootstrap/comment_edgecase/expected.hpp
+++ b/libs/preprocessor/tests/bootstrap/comment_edgecase/expected.hpp
@@ -1,0 +1,3 @@
+
+if (!isNil "test_magnification") exitWith{0.25/test_magnification};
+

--- a/libs/preprocessor/tests/bootstrap/comment_edgecase/source.hpp
+++ b/libs/preprocessor/tests/bootstrap/comment_edgecase/source.hpp
@@ -1,0 +1,7 @@
+#define QUOTE(var1) #var1
+#define DOUBLES(var1, var2) var1##_##var2
+#define ADDON test
+#define GVAR(var1) DOUBLES(ADDON, var1)
+#define QGVAR(var1) QUOTE(GVAR(var1))
+
+if (!isNil QGVAR(magnification)) exitWith{0.25/GVAR(magnification)};


### PR DESCRIPTION
Fixes issue where the `tokenstream` cursor would not be moved back when `peek_forward` is called but the next token isn't an slash.

- Fixes #462