### PR TITLE
Fall-back link creation to directory symbolic link

### DIFF
--- a/bin/src/utils/link.rs
+++ b/bin/src/utils/link.rs
@@ -7,7 +7,7 @@ pub fn create_link(link: &str, target: &str) -> Result<(), Error> {
     trace!("link {:?} => {:?}", link, target);
 
     // attempt junction
-    let out = Command::new("cmd")
+    let mut out = Command::new("cmd")
         .arg("/C")
         .arg("mklink")
         .arg("/J")


### PR DESCRIPTION
Fix compatibility with network drives (UNC paths). Related to #338.

Maybe can just do directory symbolic link at all times? They mostly behave the same.