### PR TITLE
Support --no-archive in rename zip example hook

### DIFF
--- a/book/rhai/hooks/examples.md
+++ b/book/rhai/hooks/examples.md
@@ -10,7 +10,7 @@ We want to modify the release zip to a different name format, we need to use the
 let releases = HEMTT_RFS.join("releases");
 let src = releases.join(HEMTT.project().prefix() + "-latest.zip"); // "prefix-latest.zip"
 let dst = releases.join("@" + HEMTT.project().prefix() + ".zip"); // "@prefix.zip"
-if is_file(src) { // support --no-archive
+if src.is_file() { // support --no-archive
     print("Moving zip to " + dst);
     if !src.move(dst) {
         fatal("Failed to move " + src + " to " + dst);

--- a/book/rhai/hooks/examples.md
+++ b/book/rhai/hooks/examples.md
@@ -10,9 +10,11 @@ We want to modify the release zip to a different name format, we need to use the
 let releases = HEMTT_RFS.join("releases");
 let src = releases.join(HEMTT.project().prefix() + "-latest.zip"); // "prefix-latest.zip"
 let dst = releases.join("@" + HEMTT.project().prefix() + ".zip"); // "@prefix.zip"
-print("Moving zip to " + dst);
-if !src.move(dst) {
-    fatal("Failed to move " + src + " to " + dst);
+if is_file(src) { // support --no-archive
+    print("Moving zip to " + dst);
+    if !src.move(dst) {
+        fatal("Failed to move " + src + " to " + dst);
+    }
 }
 ```
 


### PR DESCRIPTION
There might be a better way to do this? Maybe we could get `is_archive()` or something, that way we could skip a hook if the flag was actually given, and still get a proper error if the flag was not given and zip also didn't exist.