### PR TITLE
Allow projects to be within subfolders within VCS

### DIFF
--- a/bin/src/config/project/version.rs
+++ b/bin/src/config/project/version.rs
@@ -46,7 +46,7 @@ impl Options {
         let mut version = self._get()?;
 
         if let Some(length) = self.git_hash() {
-            let repo = Repository::open(".")?;
+            let repo = Repository::discover(".")?;
             let rev = repo.revparse_single("HEAD")?;
             let id = rev.id().to_string();
             version.set_build(&id[0..length as usize]);


### PR DESCRIPTION
Right now HEMTT-based projects must lie within the top level of a git repository for git hash extraction to work, this PR changes this to allow HEMTT-based projects to lie in any subdirectory below the VCS root as well.

Useful when using one git repo to version multiple related things at once (e.g. compiled components, art, models, etc) where mod-related files exist as a subdirectory within the main project.