### PR TITLE
Fix build/release commands when project is a subfolder in VCS

### DIFF
--- a/bin/src/modules/pbo.rs
+++ b/bin/src/modules/pbo.rs
@@ -27,7 +27,7 @@ pub enum Collapse {
 pub fn build(ctx: &Context, collapse: Collapse) -> Result<(), Error> {
     let version = ctx.config().version().get()?;
     let git_hash = {
-        if let Ok(repo) = Repository::open(".") {
+        if let Ok(repo) = Repository::discover(".") {
             let rev = repo.revparse_single("HEAD")?;
             let id = rev.id().to_string();
             Some(id)

--- a/bin/src/modules/sign.rs
+++ b/bin/src/modules/sign.rs
@@ -22,7 +22,7 @@ impl Module for Sign {
 
     fn check(&self, ctx: &Context) -> Result<(), Error> {
         if ctx.config().version().git_hash().is_some() {
-            Repository::open(".")?;
+            Repository::discover(".")?;
         }
         Ok(())
     }


### PR DESCRIPTION
This is a follow up to my previous PR (#533) where I missed a few places that `Repository::open` was being used instead of `Repository::discover` causing `hemtt dev` to work but `hemtt release` to fail (during PBO signing) if the project is in a subfolder.

Apologies for not thoroughly testing my changes earlier.