### PR TITLE
Fix Chocolatey pack path for Linux CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Pack for Chocolatey
         uses: crazy-max/ghaction-chocolatey@v2
         with:
-          args: pack bin\dist\hemtt.nuspec --version ${GITHUB_REF_NAME#v} --outputdirectory release
+          args: pack bin/dist/hemtt.nuspec --version ${GITHUB_REF_NAME#v} --outputdirectory release
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Runs on Linux in CI so path must use Linux path too...