### PR TITLE
Config: case warning

### DIFF
--- a/bin/src/modules/rapifier.rs
+++ b/bin/src/modules/rapifier.rs
@@ -142,7 +142,7 @@ pub fn rapify(path: WorkspacePath, _ctx: &Context) -> (Vec<String>, Result<(), E
             ))),
         );
     }
-    let out = if path.filename() == "config.cpp" {
+    let out = if path.filename().to_lowercase() == "config.cpp" {
         path.parent().join("config.bin").unwrap()
     } else {
         path

--- a/libs/preprocessor/src/codes/mod.rs
+++ b/libs/preprocessor/src/codes/mod.rs
@@ -22,3 +22,4 @@ pub mod pe8_if_undefined;
 pub mod pe9_function_call_argument_count;
 
 pub mod pw1_redefine;
+pub mod pw2_invalid_config_case;

--- a/libs/preprocessor/src/codes/pw2_invalid_config_case.rs
+++ b/libs/preprocessor/src/codes/pw2_invalid_config_case.rs
@@ -1,0 +1,43 @@
+use ariadne::Fmt;
+use hemtt_common::{reporting::Code, workspace::WorkspacePath};
+
+#[allow(unused)]
+/// Unexpected token
+pub struct InvalidConfigCase {
+    /// The [`WorkspacePath`] that was named with an invalid case
+    pub(crate) path: WorkspacePath,
+}
+
+impl Code for InvalidConfigCase {
+    fn ident(&self) -> &'static str {
+        "PW2"
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "`{}` is not a valid case for a config",
+            self.path.filename()
+        )
+    }
+
+    fn label_message(&self) -> String {
+        format!(
+            "`{}` is not a valid case for a config",
+            self.path.filename()
+        )
+    }
+
+    fn help(&self) -> Option<String> {
+        Some(format!("Rename to `{}`", self.path.as_str().to_lowercase()))
+    }
+
+    fn generate_report(&self) -> Option<String> {
+        Some(format!(
+            "{} {}\n      {}: {}",
+            format!("[{}] Warning:", self.ident()).fg(ariadne::Color::Yellow),
+            self.message(),
+            "Help".fg(ariadne::Color::Fixed(115)),
+            self.help().expect("help should be Some")
+        ))
+    }
+}

--- a/libs/preprocessor/src/processor/mod.rs
+++ b/libs/preprocessor/src/processor/mod.rs
@@ -8,6 +8,7 @@ use peekmore::{PeekMore, PeekMoreIterator};
 use crate::codes::pe18_eoi_ifstate::EoiIfState;
 use crate::codes::pe2_unexpected_eof::UnexpectedEOF;
 use crate::codes::pe3_expected_ident::ExpectedIdent;
+use crate::codes::pw2_invalid_config_case::InvalidConfigCase;
 use crate::defines::Defines;
 use crate::ifstate::IfStates;
 use crate::Error;
@@ -64,6 +65,12 @@ impl Processor {
             return Err(Error::Code(Box::new(EoiIfState {
                 token: Box::new(state.token().clone()),
             })));
+        }
+
+        if path.filename() == "Config.cpp" {
+            processor
+                .warnings
+                .push(Box::new(InvalidConfigCase { path: path.clone() }));
         }
 
         Processed::new(


### PR DESCRIPTION
- Turns `config.cpp` of any case into `config.bin`
- Warns if `config.cpp` is not all lowercase
- Closes #562 