### PR TITLE
Binarize: fix copy files from addons folder path 

### DIFF
--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -144,7 +144,7 @@ fn setup_tmp(ctx: &Context) -> Result<(), Error> {
         }
         let tmp_file = tmp
             //.join(ctx.addons().first().unwrap().prefix().as_pathbuf())
-            .parent()
+            //.parent()
             .unwrap()
             .join(file.file_name().unwrap());
         if file.metadata()?.len() > 1024 * 1024 * 10 {

--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -145,7 +145,7 @@ fn setup_tmp(ctx: &Context) -> Result<(), Error> {
         let tmp_file = tmp
             //.join(ctx.addons().first().unwrap().prefix().as_pathbuf())
             //.parent()
-            .unwrap()
+            //.unwrap()
             .join(file.file_name().unwrap());
         if file.metadata()?.len() > 1024 * 1024 * 10 {
             warn!(

--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -143,7 +143,7 @@ fn setup_tmp(ctx: &Context) -> Result<(), Error> {
             continue;
         }
         let tmp_file = tmp
-            .join(ctx.addons().first().unwrap().prefix().as_pathbuf())
+            //.join(ctx.addons().first().unwrap().prefix().as_pathbuf())
             .parent()
             .unwrap()
             .join(file.file_name().unwrap());

--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -143,9 +143,11 @@ fn setup_tmp(ctx: &Context) -> Result<(), Error> {
             continue;
         }
         let tmp_file = tmp
-            //.join(ctx.addons().first().unwrap().prefix().as_pathbuf())
-            //.parent()
-            //.unwrap()
+            .join(ctx.addons().first().unwrap().prefix().as_pathbuf())
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
             .join(file.file_name().unwrap());
         if file.metadata()?.len() > 1024 * 1024 * 10 {
             warn!(

--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -142,13 +142,7 @@ fn setup_tmp(ctx: &Context) -> Result<(), Error> {
         if file.is_dir() {
             continue;
         }
-        let tmp_file = tmp
-            .join(ctx.addons().first().unwrap().prefix().as_pathbuf())
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join(file.file_name().unwrap());
+        let tmp_file = tmp.join(file.file_name().unwrap());
         if file.metadata()?.len() > 1024 * 1024 * 10 {
             warn!(
                 "File `{}` is larger than 10MB, this will slow builds.",

--- a/bin/src/modules/binarize.rs
+++ b/bin/src/modules/binarize.rs
@@ -139,9 +139,11 @@ impl Module for Binarize {
             let exe = self.command.as_ref().unwrap();
             let mut cmd = Command::new(exe);
             cmd.args([
+                "-norecurse",
                 "-always",
                 "-silent",
                 "-maxProcesses=0",
+                format!("-binPath={}", tmp_source.display().to_string()),
                 &target.source,
                 &target.output,
                 &target.entry,

--- a/bin/src/modules/binarize.rs
+++ b/bin/src/modules/binarize.rs
@@ -139,7 +139,6 @@ impl Module for Binarize {
             let exe = self.command.as_ref().unwrap();
             let mut cmd = Command::new(exe);
             cmd.args([
-                "-norecurse",
                 "-always",
                 "-silent",
                 "-maxProcesses=0",

--- a/bin/src/modules/binarize.rs
+++ b/bin/src/modules/binarize.rs
@@ -143,7 +143,6 @@ impl Module for Binarize {
                 "-always",
                 "-silent",
                 "-maxProcesses=0",
-                &format!("-binPath={}", tmp_source.display().to_string()),
                 &target.source,
                 &target.output,
                 &target.entry,

--- a/bin/src/modules/binarize.rs
+++ b/bin/src/modules/binarize.rs
@@ -143,7 +143,7 @@ impl Module for Binarize {
                 "-always",
                 "-silent",
                 "-maxProcesses=0",
-                format!("-binPath={}", tmp_source.display().to_string()),
+                &format!("-binPath={}", tmp_source.display().to_string()),
                 &target.source,
                 &target.output,
                 &target.entry,


### PR DESCRIPTION
Fix path from #590. Tested only on CUP, ~~it might go a folder too high in other mods? That would still work though~~.