### PR TITLE
ASC - Don't copy .inc.sqf for building

### DIFF
--- a/bin/src/modules/asc.rs
+++ b/bin/src/modules/asc.rs
@@ -82,7 +82,9 @@ impl Module for ArmaScriptCompiler {
                     if entry.extension() != sqf_ext {
                         continue;
                     }
-                    if entry.filename().ends_with(".inc.sqf") { continue; }
+                    if entry.filename().ends_with(".inc.sqf") {
+                        continue;
+                    }
                     entries.push(entry);
                 }
             }

--- a/bin/src/modules/asc.rs
+++ b/bin/src/modules/asc.rs
@@ -82,7 +82,7 @@ impl Module for ArmaScriptCompiler {
                     if entry.extension() != sqf_ext {
                         continue;
                     }
-                    if entry.filename().ends_with("inc.sqf") { continue; }
+                    if entry.filename().ends_with(".inc.sqf") { continue; }
                     entries.push(entry);
                 }
             }

--- a/bin/src/modules/asc.rs
+++ b/bin/src/modules/asc.rs
@@ -82,6 +82,7 @@ impl Module for ArmaScriptCompiler {
                     if entry.extension() != sqf_ext {
                         continue;
                     }
+                    if entry.filename().ends_with("inc.sqf") { continue; }
                     entries.push(entry);
                 }
             }


### PR DESCRIPTION
.inc.sqf get copied to temp for asc building

```
compile AppData/Local/Temp/hemtt/DEV_CBA_A3/asc/output/x/cba/addons/ui/initSettings.inc.sqfc
[ERR] [L2|C9|/x/cba/addons/ui/initSettings.inc.sqf]	Parse Error: syntax error, unexpected (, expecting ] or ","
```
when it fails it triggers output
` WARN ThreadId(01) ASC 'Parse Error' - check .hemttout/asc.log`