### PR TITLE
Improve support for direct mission launching

### DIFF
--- a/bin/src/commands/launch/mod.rs
+++ b/bin/src/commands/launch/mod.rs
@@ -283,24 +283,26 @@ pub fn execute(matches: &ArgMatches) -> Result<Report, Error> {
 
         if !path.is_absolute() {
             path = std::env::current_dir()?.join(mission);
-        }
 
-        if !path.ends_with("mission.sqm") {
-            path.push("mission.sqm");
-        }
+            if !path.ends_with("mission.sqm") {
+                path.push("mission.sqm");
+            }
 
-        if !path.is_file() {
-            path = std::env::current_dir()?
-                .join(".hemtt")
-                .join("missions")
-                .join(mission)
-                .join("mission.sqm");
-        }
+            if !path.is_file() {
+                path = std::env::current_dir()?
+                    .join(".hemtt")
+                    .join("missions")
+                    .join(mission)
+                    .join("mission.sqm");
+            }
 
-        if path.is_file() {
-            args.push(format!("\"{}\"", path.display()));
+            if path.is_file() {
+                args.push(format!("\"{}\"", path.display()));
+            } else {
+                warn!("Could not launch with mission `{}`", mission);
+            }
         } else {
-            warn!("Could not launch with mission `{}`", mission);
+            warn!("Absolute paths are not supported for missions in the launch config")
         }
     }
 

--- a/bin/src/commands/launch/mod.rs
+++ b/bin/src/commands/launch/mod.rs
@@ -278,6 +278,32 @@ pub fn execute(matches: &ArgMatches) -> Result<Report, Error> {
             .join(" "),
     );
 
+    if let Some(mission) = launch.mission() {
+        let mut path = PathBuf::from(mission);
+
+        if !path.is_absolute() {
+            path = std::env::current_dir()?.join(mission);
+        }
+
+        if !path.ends_with("mission.sqm") {
+            path.push("mission.sqm");
+        }
+
+        if !path.is_file() {
+            path = std::env::current_dir()?
+                .join(".hemtt")
+                .join("missions")
+                .join(mission)
+                .join("mission.sqm");
+        }
+
+        if path.is_file() {
+            args.push(format!("\"{}\"", path.display().to_string()));
+        } else {
+            warn!("Could not launch with mission `{}`", mission);
+        }
+    }
+
     // let with_server = matches.get_flag("server");
     let with_server = false;
 

--- a/bin/src/commands/launch/mod.rs
+++ b/bin/src/commands/launch/mod.rs
@@ -298,7 +298,7 @@ pub fn execute(matches: &ArgMatches) -> Result<Report, Error> {
         }
 
         if path.is_file() {
-            args.push(format!("\"{}\"", path.display().to_string()));
+            args.push(format!("\"{}\"", path.display()));
         } else {
             warn!("Could not launch with mission `{}`", mission);
         }

--- a/book/commands/launch.md
+++ b/book/commands/launch.md
@@ -72,13 +72,13 @@ dlc = [
 optionals = [
     "caramel",
 ]
+mission = "test.VR" # Mission to launch directly into the editor with
 parameters = [
     "-skipIntro",           # These parameters are passed to the Arma 3 executable
     "-noSplash",            # They do not need to be added to your list
     "-showScriptErrors",    # You can add additional parameters here
     "-debug",
     "-filePatching",
-    "Path\\To\\mission.sqm", # Launch into existing Editor Mission - \\ needed
 ]
 executable = "arma3" # Default: "arma3_x64"
 
@@ -118,6 +118,10 @@ Currently supported DLCs:
 ### optionals
 
 A list of optional addon folders to launch with your mod.
+
+### mission
+
+The mission to launch directly into the editor with. This can be specified as either the name of a folder in `.hemtt/missions/` (e.g., `test.VR` would launch `.hemtt/missions/test.VR/mission.sqm`) or the relative (to the project root) or absolute path to a `mission.sqm` file or a folder containing it.
 
 ### parameters
 

--- a/book/commands/launch.md
+++ b/book/commands/launch.md
@@ -121,7 +121,7 @@ A list of optional addon folders to launch with your mod.
 
 ### mission
 
-The mission to launch directly into the editor with. This can be specified as either the name of a folder in `.hemtt/missions/` (e.g., `test.VR` would launch `.hemtt/missions/test.VR/mission.sqm`) or the relative (to the project root) or absolute path to a `mission.sqm` file or a folder containing it.
+The mission to launch directly into the editor with. This can be specified as either the name of a folder in `.hemtt/missions/` (e.g., `test.VR` would launch `.hemtt/missions/test.VR/mission.sqm`) or the relative (to the project root) path to a `mission.sqm` file or a folder containing it.
 
 ### parameters
 

--- a/libs/common/src/project/hemtt.rs
+++ b/libs/common/src/project/hemtt.rs
@@ -88,6 +88,10 @@ pub struct LaunchOptions {
     optionals: Vec<String>,
 
     #[serde(default)]
+    /// Mission to launch directly into the editor with
+    mission: Option<String>,
+
+    #[serde(default)]
     /// Extra launch parameters
     parameters: Vec<String>,
 
@@ -119,6 +123,12 @@ impl LaunchOptions {
     /// Optional addons that should be built into the mod
     pub fn optionals(&self) -> &[String] {
         &self.optionals
+    }
+
+    #[must_use]
+    /// Mission to launch directly into the editor with
+    pub const fn mission(&self) -> Option<&String> {
+        self.mission.as_ref()
     }
 
     #[must_use]


### PR DESCRIPTION
Improve support for directly launching into 3DEN with an existing mission by allowing missions contained in the project to be used.

Adds a `mission` configuration parameter that specifies whether a launch configuration loads directly into a mission. Can be specified as either:
  - a folder name in `.hemtt/missions/` (e.g., `mission = "test.VR"` would launch `.hemtt/missions/test.VR/mission.sqm`).
  - a relative path to a `mission.sqm` file (or folder containing it).

Tested all of the various cases and everything looks good. I am not too familiar with Rust and this is just the result of my messing around. So, the code could probably be improved.

Close #621 