### PR TITLE
fix binarize not running on 1.11.1

### DIFF
--- a/bin/src/modules/binarize/mod.rs
+++ b/bin/src/modules/binarize/mod.rs
@@ -21,7 +21,6 @@ mod error;
 #[derive(Default)]
 pub struct Binarize {
     command: Option<String>,
-    available: bool,
 }
 
 impl Module for Binarize {
@@ -36,12 +35,10 @@ impl Module for Binarize {
         let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
         let Ok(key) = hkcu.open_subkey("Software\\Bohemia Interactive\\binarize") else {
             report.warn(ToolsNotFound::code());
-            self.available = false;
             return Ok(report);
         };
         let Ok(path) = key.get_value::<String, _>("path") else {
             report.warn(ToolsNotFound::code());
-            self.available = false;
             return Ok(report);
         };
         let path = PathBuf::from(path).join("binarize_x64.exe");
@@ -55,13 +52,12 @@ impl Module for Binarize {
     fn init(&mut self, _ctx: &Context) -> Result<Report, Error> {
         let mut report = Report::new();
         report.warn(PlatformNotSupported::code());
-        self.available = false;
         Ok(report)
     }
 
     #[allow(clippy::too_many_lines)]
     fn pre_build(&self, ctx: &Context) -> Result<Report, Error> {
-        if !self.available {
+        if self.command.is_none() {
             return Ok(Report::new());
         }
         let mut targets = Vec::with_capacity(ctx.addons().len());


### PR DESCRIPTION
I don't know what I was thinking when I wrote this... the command exe was already in an option.

When will I stop fixing HEMTT bugs in the middle of the night (and introducing new ones simultaneously)? Never.

Binarize was broken on linux? Fixed by silently skipping on all platforms... Fixes #660 