### PR TITLE
launch: extend configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -196,15 +196,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.3"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
 
 [[package]]
 name = "byteorder"
@@ -247,10 +247,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -309,18 +310,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -377,9 +378,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -848,9 +849,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1050,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1208,6 +1209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1349,9 +1359,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lsp-types"
-version = "0.95.0"
+version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158c1911354ef73e8fe42da6b10c0484cb65c7f1007f28022e847706c1ab6984"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
@@ -1750,9 +1760,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1868,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1885,9 +1895,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
  "base64",
  "bytes",
@@ -2163,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2340,18 +2350,18 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2368,9 +2378,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2453,18 +2463,18 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2567,7 +2577,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.48.0",
@@ -2599,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.10"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2620,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "c12219811e0c1ba077867254e5ad62ee2c9c190b0d957110750ac0cda1ae96cd"
 dependencies = [
  "indexmap",
  "serde",
@@ -2754,9 +2763,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -2826,10 +2835,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.91"
+name = "wasite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2837,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2852,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2864,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2874,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2887,15 +2902,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2909,11 +2924,12 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall",
+ "wasite",
  "web-sys",
 ]
 

--- a/bin/src/commands/launch/error/bcle1_preset_not_found.rs
+++ b/bin/src/commands/launch/error/bcle1_preset_not_found.rs
@@ -1,16 +1,13 @@
-use std::{ops::Range, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use hemtt_common::{
-    reporting::{Code, Diagnostic, Label},
+    reporting::{Code, Diagnostic},
     similar_values,
-    workspace::{LayerType, Workspace, WorkspacePath},
 };
 
 pub struct PresetNotFound {
-    project_toml: WorkspacePath,
     name: String,
     similar: Vec<String>,
-    position: Option<Range<usize>>,
 }
 
 impl Code for PresetNotFound {
@@ -31,21 +28,12 @@ impl Code for PresetNotFound {
     }
 
     fn diagnostic(&self) -> Option<Diagnostic> {
-        Some({
-            let mut diag = Diagnostic::simple(self);
-            if let Some(position) = &self.position {
-                diag = diag.with_label(
-                    Label::primary(self.project_toml.clone(), position.clone())
-                        .with_message("preset not found"),
-                );
-            }
-            diag
-        })
+        Some(Diagnostic::simple(self))
     }
 }
 
 impl PresetNotFound {
-    pub fn code(launch: &str, name: String, path: &Path) -> Arc<dyn Code> {
+    pub fn code(name: String, path: &Path) -> Arc<dyn Code> {
         let presets = path.read_dir().map_or_else(
             |_| vec![],
             |files| {
@@ -65,23 +53,10 @@ impl PresetNotFound {
             },
         );
 
-        let position = std::fs::read_to_string(".hemtt/project.toml")
-            .map_or(None, |content| attempt_locate(&content, launch, &name));
+        // let position = std::fs::read_to_string(".hemtt/project.toml")
+        //     .map_or(None, |content| attempt_locate(&content, launch, &name));
 
         Arc::new(Self {
-            project_toml: {
-                Workspace::builder()
-                    .physical(
-                        &std::env::current_dir().expect("to be in a folder"),
-                        LayerType::Source,
-                    )
-                    .finish(None, false)
-                    .expect("can create workspace")
-                    .join(".hemtt")
-                    .expect("project.toml must exist to get here")
-                    .join("project.toml")
-                    .expect("project.toml must exist to get here")
-            },
             similar: similar_values(
                 &name,
                 &presets
@@ -93,65 +68,6 @@ impl PresetNotFound {
             .map(std::string::ToString::to_string)
             .collect(),
             name,
-            position,
         })
-    }
-}
-
-fn attempt_locate(content: &str, launch: &str, preset: &str) -> Option<Range<usize>> {
-    let header = format!("[hemtt.launch.{launch}]");
-    let preset_line = format!("\"{preset}\"");
-    let mut in_section = false;
-    let mut in_presets = false;
-    let mut offset = 0;
-    for line in content.lines() {
-        if line.starts_with(&header) {
-            in_section = true;
-        } else if in_section && line.starts_with('[') {
-            in_section = false;
-            in_presets = false;
-        } else if in_section && line.starts_with("presets") {
-            in_presets = true;
-        } else if in_presets && line.contains(&preset_line) {
-            let start = offset + line.find(&preset_line).unwrap();
-            let end = start + preset_line.len();
-            return Some(start + 1..end - 1);
-        }
-        offset += line.len() + 1;
-    }
-    None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_attempt_locate() {
-        let content = r#"
-[hemtt.launch.server]
-presets = [
-    "test",
-    "test2",
-    "test3",
-]
-"#
-        .replace("\r\n", "\n");
-        assert_eq!(
-            attempt_locate(&content, "server", "test"),
-            Some(40..44),
-            "test"
-        );
-        assert_eq!(
-            attempt_locate(&content, "server", "test2"),
-            Some(52..57),
-            "test2"
-        );
-        assert_eq!(
-            attempt_locate(&content, "server", "test3"),
-            Some(65..70),
-            "test3"
-        );
-        assert_eq!(attempt_locate(&content, "server", "test4"), None, "test4");
     }
 }

--- a/bin/src/commands/launch/mod.rs
+++ b/bin/src/commands/launch/mod.rs
@@ -1,9 +1,6 @@
 mod error;
 
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use clap::{ArgAction, ArgMatches, Command};
 use hemtt_common::{
@@ -109,7 +106,7 @@ pub fn execute(matches: &ArgMatches) -> Result<Report, Error> {
         .hemtt()
         .launch(&launch_config)
         .or(if launch_config == "default" {
-            Some(Cow::Owned(LaunchOptions::default()))
+            Some(LaunchOptions::default())
         } else {
             None
         })

--- a/bin/src/commands/launch/mod.rs
+++ b/bin/src/commands/launch/mod.rs
@@ -108,13 +108,16 @@ pub fn execute(matches: &ArgMatches) -> Result<Report, Error> {
     } else if let Some(launch) = launch_config
         .iter()
         .map(|c| {
-            config.hemtt().launch(c).map_or_else(|| {
-                report.error(LaunchConfigNotFound::code(
-                    (*c).to_string(),
-                    &config.hemtt().launch_keys(),
-                ));
-                None
-            }, Some)
+            config.hemtt().launch(c).map_or_else(
+                || {
+                    report.error(LaunchConfigNotFound::code(
+                        (*c).to_string(),
+                        &config.hemtt().launch_keys(),
+                    ));
+                    None
+                },
+                Some,
+            )
         })
         .collect::<Option<Vec<_>>>()
     {

--- a/book/commands/launch.md
+++ b/book/commands/launch.md
@@ -90,7 +90,18 @@ workshop = [
 dlc = [
     "S.O.G. Prairie Fire",
 ]
+
+# Launched with `hemtt launch vn-ace
+[hemtt.launch.vn-ace]
+extends = "vn"
+workshop = [
+    "463939057", # ACE3's Workshop ID
+]
 ```
+
+### extends
+
+The name of another configuration to extend. This will merge all arrays with the base configuration, and override any duplicate keys.
 
 ### workshop
 

--- a/book/commands/launch.md
+++ b/book/commands/launch.md
@@ -2,11 +2,11 @@
 
 <pre><code>Launch Arma 3 with your mod and dependencies.
 
-Usage: hemtt launch [OPTIONS] [config] [-- &lt;passthrough&gt;...]
+Usage: hemtt launch [OPTIONS] [config]... [-- &lt;passthrough&gt;...]
 
 Arguments:
-  [config]
-        Launches with the specified `hemtt.launch.<config>` configuration
+  [config]...
+        Launches with the specified `hemtt.launch.<config>` configurations
 
   [passthrough]...
         Passthrough additional arguments to Arma 3
@@ -48,6 +48,8 @@ Options:
 </pre>
 
 `hemtt launch` is used to build and launch a dev version of your mod. It will run the [`hemtt dev`](dev.md) command internally after a few checks, options are passed to the `dev` command.
+
+You can chain multiple configurations together, and they will be overlayed from left to right. Any arrays will be concatenated, and any duplicate keys will be overridden.
 
 ## Configuration
 

--- a/libs/common/src/arma/dlc.rs
+++ b/libs/common/src/arma/dlc.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(PartialEq, Eq, Clone, Debug, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, PartialOrd, Ord, Hash, Copy)]
 #[cfg_attr(test, derive(strum::EnumIter))]
 /// DLCs that require opt-in.
 pub enum DLC {

--- a/libs/common/src/project/hemtt.rs
+++ b/libs/common/src/project/hemtt.rs
@@ -125,6 +125,37 @@ pub struct LaunchOptions {
 
 impl LaunchOptions {
     #[must_use]
+    /// Overlay another launch config
+    pub fn overlay(&self, other: &Self) -> Self {
+        let mut base = self.clone();
+        base.workshop.extend(other.workshop.clone());
+        base.dlc.extend(other.dlc.clone());
+        base.presets.extend(other.presets.clone());
+        base.optionals.extend(other.optionals.clone());
+        base.parameters.extend(other.parameters.clone());
+        if let Some(executable) = &other.executable {
+            base.executable = Some(executable.clone());
+        }
+        if let Some(mission) = &other.mission {
+            base.mission = Some(mission.clone());
+        }
+        base
+    }
+
+    pub fn dedup(&mut self) {
+        self.workshop.sort();
+        self.workshop.dedup();
+        self.dlc.sort();
+        self.dlc.dedup();
+        self.presets.sort();
+        self.presets.dedup();
+        self.optionals.sort();
+        self.optionals.dedup();
+        self.parameters.sort();
+        self.parameters.dedup();
+    }
+
+    #[must_use]
     /// Preset to extend
     pub const fn extends(&self) -> Option<&String> {
         self.extends.as_ref()

--- a/libs/common/src/project/mod.rs
+++ b/libs/common/src/project/mod.rs
@@ -120,6 +120,10 @@ impl ProjectConfig {
         }
 
         CONFIG_DEPRECATION.call_once(|| {
+            if file.contains("[hemtt.launch]") {
+                warn!("hemtt.launch is deprecated, use hemtt.launch.default instead");
+            }
+
             if file.contains("[asc]") {
                 warn!("ASC config is no longer used");
             }

--- a/libs/common/tests/config.rs
+++ b/libs/common/tests/config.rs
@@ -1,0 +1,16 @@
+use std::path::Path;
+
+use hemtt_common::project::ProjectConfig;
+
+#[test]
+fn extends() {
+    let config = ProjectConfig::from_file(Path::new("tests/config/extends.toml")).unwrap();
+    let launch = config.hemtt().launch("layer2").unwrap();
+    assert_eq!(launch.workshop().len(), 9);
+    assert_eq!(launch.dlc().len(), 3);
+    assert_eq!(launch.presets().len(), 3);
+    assert_eq!(launch.optionals().len(), 3);
+    assert_eq!(launch.parameters().len(), 3);
+    assert_eq!(launch.mission(), Some(&"base".to_string()));
+    assert!(!launch.executable().starts_with("arma"));
+}

--- a/libs/common/tests/config/extends.toml
+++ b/libs/common/tests/config/extends.toml
@@ -1,0 +1,27 @@
+name = "extends"
+prefix = "extends"
+
+[hemtt.launch.base]
+workshop = ["1","2","3"]
+dlc = ["vn"]
+presets = ["preset1"]
+optionals = ["optional1"]
+mission = "base"
+parameters = ["-mod=@base"]
+
+[hemtt.launch.layer1]
+extends = "base"
+workshop = ["4","5","6"]
+dlc = ["ws"]
+presets = ["preset2"]
+optionals = ["optional2"]
+parameters = ["-mod=@layer1"]
+executable = "asdf"
+
+[hemtt.launch.layer2]
+extends = "layer1"
+workshop = ["7","8","9"]
+dlc = ["csla"]
+presets = ["preset3"]
+optionals = ["optional3"]
+parameters = ["-mod=@layer2"]


### PR DESCRIPTION
Adds `extend` to `hemtt.launch`, which will append the arrays and overwrite keys in previous layers. Can be recursive (if you make a loop that's your fault)