### PR TITLE
CI - Replace deprecated actions-rs and update actions

### DIFF
--- a/.github/workflows/browser.yaml
+++ b/.github/workflows/browser.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wasm
-        path: | 
+        path: |
             hemtt_paa_bg.wasm
             hemtt_paa.js
 
@@ -39,7 +39,7 @@ jobs:
     needs: build-wasm
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
     - name: Download wasm
       uses: actions/download-artifact@v4
       with:
@@ -68,7 +68,7 @@ jobs:
     needs: build-wasm
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
     - name: Download wasm
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,11 +26,9 @@ jobs:
             exe: hemtt.exe
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - run: echo "RELEASE=true" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/') && matrix.os.name == 'ubuntu'
       - run: echo "RELEASE=true" >> $env:GITHUB_ENV
@@ -40,10 +38,7 @@ jobs:
         with:
           key: build
       - name: Compile
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+        run: cargo build --release
       - name: Upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,9 +31,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
       - name: Install Arma 3 Tools
         if: startsWith(matrix.os.runner, 'windows')
         uses: arma-actions/arma3-tools@master
@@ -67,7 +65,8 @@ jobs:
           name: ${{ matrix.os.name }}-coverage
           path: out.lcov
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: out.lcov
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,12 +36,9 @@ jobs:
         with:
           submodules: true
       - name: Install ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ matrix.toolchain }}
+        run: cargo clippy --all-targets --all-features

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           toolsUrl: ${{ secrets.ARMA3_TOOLS_URL }}
       - name: Install ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: cargo generate-lockfile


### PR DESCRIPTION
`CODECOV_TOKEN` secret will have to be added for the codecov action update. See https://docs.codecov.com/docs/adding-the-codecov-token#github-actions