### PR TITLE
Workspace: insensitive strip prefix on linux

### DIFF
--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -41,7 +41,7 @@ impl Module for SQFCompiler {
         let reports = entries
             .par_iter()
             .map(|(addon, entry)| {
-                trace!("asc compiling {}", entry);
+                trace!("sqf compiling {}", entry);
                 let mut report = Report::new();
                 let processed = Processor::run(entry)?;
                 for warning in processed.warnings() {

--- a/libs/common/src/lib.rs
+++ b/libs/common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod math;
 pub mod prefix;
 pub mod project;
 pub mod steam;
+pub mod strip;
 pub mod version;
 
 mod sign_version;

--- a/libs/common/src/strip.rs
+++ b/libs/common/src/strip.rs
@@ -1,0 +1,39 @@
+pub trait StripInsensitive {
+    fn strip_prefix_insensitive(&self, prefix: &str) -> Option<&str>;
+}
+
+impl StripInsensitive for str {
+    fn strip_prefix_insensitive(&self, prefix: &str) -> Option<&str> {
+        if self.len() < prefix.len() {
+            return None;
+        }
+        if self[..prefix.len()].eq_ignore_ascii_case(prefix) {
+            Some(&self[prefix.len()..])
+        } else {
+            None
+        }
+    }
+}
+
+impl StripInsensitive for String {
+    fn strip_prefix_insensitive(&self, prefix: &str) -> Option<&str> {
+        self.as_str().strip_prefix_insensitive(prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_prefix_insensitive() {
+        assert_eq!("foobar".strip_prefix_insensitive("foo"), Some("bar"));
+        assert_eq!("foobar".strip_prefix_insensitive("FOO"), Some("bar"));
+        assert_eq!("foobar".strip_prefix_insensitive("bar"), None);
+        assert_eq!("foobar".strip_prefix_insensitive("baz"), None);
+        assert_eq!("FoObAr".strip_prefix_insensitive("foo"), Some("bAr"));
+        assert_eq!("FoObAr".strip_prefix_insensitive("FOO"), Some("bAr"));
+        assert_eq!("FoObAr".strip_prefix_insensitive("bar"), None);
+        assert_eq!("FoObAr".strip_prefix_insensitive("baz"), None);
+    }
+}

--- a/libs/workspace/src/path.rs
+++ b/libs/workspace/src/path.rs
@@ -1,5 +1,6 @@
 use std::{hash::Hasher, sync::Arc};
 
+use hemtt_common::strip::StripInsensitive;
 use vfs::{SeekAndWrite, VfsPath};
 
 use super::{Error, LayerType, Workspace};
@@ -208,9 +209,6 @@ impl WorkspacePath {
                 .iter()
                 .find(|(p, _)| path_lower.starts_with(&format!("{}/", p.to_lowercase())))
             {
-                // Windows needs case insensitivity because p3ds are a
-                // disaster. On Linux we'll be more strict to avoid
-                // pain and suffering.
                 let path = if cfg!(windows) {
                     root.join(
                         path_lower
@@ -221,7 +219,7 @@ impl WorkspacePath {
                     )?
                 } else {
                     root.join(
-                        path.strip_prefix(base)
+                        path.strip_prefix_insensitive(base)
                             .unwrap_or(&path)
                             .strip_prefix('/')
                             .unwrap_or(&path),

--- a/libs/workspace/src/path.rs
+++ b/libs/workspace/src/path.rs
@@ -209,6 +209,9 @@ impl WorkspacePath {
                 .iter()
                 .find(|(p, _)| path_lower.starts_with(&format!("{}/", p.to_lowercase())))
             {
+                // Windows needs case insensitivity because p3ds are a
+                // disaster. On Linux we'll be more strict to avoid
+                // pain and suffering.
                 let path = if cfg!(windows) {
                     root.join(
                         path_lower


### PR DESCRIPTION
- Fixing an issue with locating full paths within a workspace with a mix of capitalization on Linux