### PR TITLE
Analyze - Skip SAA1 suggestion if consts used in `isNil` check

### DIFF
--- a/libs/sqf/src/analyze/if_assign.rs
+++ b/libs/sqf/src/analyze/if_assign.rs
@@ -28,16 +28,12 @@ fn check_expression(expression: &Expression, processed: &Processed) -> Vec<Arc<d
                 let rhs = extract_constant(rhs_expr);
                 if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
                     // Skip if consts are used in a isNil check (e.g. [x, 5] select (isNil "x") will error in scheduled)
-                    let cond_lower = condition.source().to_lowercase();
-                    let lhs_lower = lhs.0.to_lowercase();
-                    let rhs_lower = rhs.0.to_lowercase();
-                    if cond_lower.contains(&format!("isnil \"{}\"", lhs_lower))
-                        || cond_lower.contains(&format!("isnil {{{}}}", lhs_lower))
-                        || cond_lower.contains(&format!("isnil \"{}\"", rhs_lower))
-                        || cond_lower.contains(&format!("isnil {{{}}}", rhs_lower))
+                    if let Expression::UnaryCommand(UnaryCommand::Named(name), _, _) = &**condition
                     {
-                        return Vec::new();
-                    };
+                        if name.to_lowercase() == "isnil" {
+                            return Vec::new();
+                        }
+                    }
                     return vec![Arc::new(IfAssign::new(
                         if_cmd.span(),
                         (condition.source(), condition.full_span()),

--- a/libs/sqf/src/analyze/if_assign.rs
+++ b/libs/sqf/src/analyze/if_assign.rs
@@ -31,10 +31,11 @@ fn check_expression(expression: &Expression, processed: &Processed) -> Vec<Arc<d
                     let cond_lower = condition.source().to_lowercase();
                     let lhs_lower = lhs.0.to_lowercase();
                     let rhs_lower = rhs.0.to_lowercase();
-                    if cond_lower.contains(&format!("isnil \"{}\"", lhs_lower)) 
-                    || cond_lower.contains(&format!("isnil {{{}}}", lhs_lower)) 
-                    || cond_lower.contains(&format!("isnil \"{}\"", rhs_lower)) 
-                    || cond_lower.contains(&format!("isnil {{{}}}", rhs_lower)) {
+                    if cond_lower.contains(&format!("isnil \"{}\"", lhs_lower))
+                        || cond_lower.contains(&format!("isnil {{{}}}", lhs_lower))
+                        || cond_lower.contains(&format!("isnil \"{}\"", rhs_lower))
+                        || cond_lower.contains(&format!("isnil {{{}}}", rhs_lower))
+                    {
                         return Vec::new();
                     };
                     return vec![Arc::new(IfAssign::new(


### PR DESCRIPTION
SAA1
```
38 │ if (isNil "x") then {5} else {x};
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use select
   │
   = note: the if and else blocks only return constant values
           select is faster in this case
   = try: [x, 5] select (isNil "x")
   ```
the replacement is not safe in scheduled
```
[] spawn {
  [x, 5] select (isNil "x")
};
    Error Undefined variable in expression: x
```