### PR TITLE
binarize: specify folder

### DIFF
--- a/bin/src/modules/binarize/mod.rs
+++ b/bin/src/modules/binarize/mod.rs
@@ -69,6 +69,7 @@ impl Module for Binarize {
                 report.warn(ToolsNotFound::code());
                 return Ok(report);
             };
+            PathBuf::from(path)
         };
         let path = folder.join("binarize_x64.exe");
         if path.exists() {

--- a/bin/src/modules/binarize/mod.rs
+++ b/bin/src/modules/binarize/mod.rs
@@ -56,8 +56,10 @@ impl Module for Binarize {
         let mut report = Report::new();
 
         let folder = if let Ok(path) = std::env::var("HEMTT_BINARIZE_PATH") {
+            trace!("Using Binarize path from HEMTT_BINARIZE_PATH");
             PathBuf::from(path)
         } else {
+            trace!("Using Binarize path from registry");
             let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
             let Ok(key) = hkcu.open_subkey("Software\\Bohemia Interactive\\binarize") else {
                 report.warn(ToolsNotFound::code());
@@ -71,6 +73,8 @@ impl Module for Binarize {
         let path = folder.join("binarize_x64.exe");
         if path.exists() {
             self.command = Some(path.display().to_string());
+        } else {
+            report.warn(ToolsNotFound::code());
         }
         Ok(report)
     }

--- a/bin/src/modules/binarize/mod.rs
+++ b/bin/src/modules/binarize/mod.rs
@@ -54,16 +54,21 @@ impl Module for Binarize {
     #[cfg(windows)]
     fn init(&mut self, _ctx: &Context) -> Result<Report, Error> {
         let mut report = Report::new();
-        let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
-        let Ok(key) = hkcu.open_subkey("Software\\Bohemia Interactive\\binarize") else {
-            report.warn(ToolsNotFound::code());
-            return Ok(report);
+
+        let folder = if let Ok(path) = std::env::var("HEMTT_BINARIZE_PATH") {
+            PathBuf::from(path)
+        } else {
+            let hkcu = winreg::RegKey::predef(winreg::enums::HKEY_CURRENT_USER);
+            let Ok(key) = hkcu.open_subkey("Software\\Bohemia Interactive\\binarize") else {
+                report.warn(ToolsNotFound::code());
+                return Ok(report);
+            };
+            let Ok(path) = key.get_value::<String, _>("path") else {
+                report.warn(ToolsNotFound::code());
+                return Ok(report);
+            };
         };
-        let Ok(path) = key.get_value::<String, _>("path") else {
-            report.warn(ToolsNotFound::code());
-            return Ok(report);
-        };
-        let path = PathBuf::from(path).join("binarize_x64.exe");
+        let path = folder.join("binarize_x64.exe");
         if path.exists() {
             self.command = Some(path.display().to_string());
         }


### PR DESCRIPTION
Closes #708 

`HEMTT_BINARIZE_PATH` can be set to the folder that contains `binarize_x64.exe`