### PR TITLE
config: Show EOF errors and fix seg fault

### DIFF
--- a/libs/config/src/analyze/codes/mod.rs
+++ b/libs/config/src/analyze/codes/mod.rs
@@ -50,7 +50,7 @@ impl ChumskyCode {
             diag.notes.push(format!(
                 "The processed output of the line with the error was:\n{} ",
                 {
-                    let mut start = self.err.span().start;
+                    let mut start = std::cmp::min(self.err.span().start, processed.as_str().len() - 1);
                     while start > 0 && processed.as_str().as_bytes()[start] != b'\n' {
                         start -= 1;
                     }

--- a/libs/config/src/analyze/codes/mod.rs
+++ b/libs/config/src/analyze/codes/mod.rs
@@ -50,7 +50,8 @@ impl ChumskyCode {
             diag.notes.push(format!(
                 "The processed output of the line with the error was:\n{} ",
                 {
-                    let mut start = std::cmp::min(self.err.span().start, processed.as_str().len() - 1);
+                    let mut start =
+                        std::cmp::min(self.err.span().start, processed.as_str().len() - 1);
                     while start > 0 && processed.as_str().as_bytes()[start] != b'\n' {
                         start -= 1;
                     }

--- a/libs/workspace/src/reporting/diagnostic/mod.rs
+++ b/libs/workspace/src/reporting/diagnostic/mod.rs
@@ -43,10 +43,16 @@ impl Diagnostic {
 
     pub fn new_for_processed(
         code: &impl Code,
-        span: std::ops::Range<usize>,
+        mut span: std::ops::Range<usize>,
         processed: &crate::reporting::Processed,
     ) -> Option<Self> {
         let mut diag = Self::new(code.ident(), code.message()).set_severity(code.severity());
+
+        // Error out out bounds, will never show, just use last char
+        if span.start == processed.as_str().len() {
+            span.start = processed.as_str().len()-1;
+            span.end = processed.as_str().len()-1;
+        }
         let map_start = processed.mapping(span.start)?;
         let map_end = processed.mapping(span.end)?;
         let map_file = processed.source(map_start.source())?;

--- a/libs/workspace/src/reporting/diagnostic/mod.rs
+++ b/libs/workspace/src/reporting/diagnostic/mod.rs
@@ -50,8 +50,8 @@ impl Diagnostic {
 
         // Error out out bounds, will never show, just use last char
         if span.start == processed.as_str().len() {
-            span.start = processed.as_str().len()-1;
-            span.end = processed.as_str().len()-1;
+            span.start = processed.as_str().len() - 1;
+            span.end = processed.as_str().len() - 1;
         }
         let map_start = processed.mapping(span.start)?;
         let map_end = processed.mapping(span.end)?;


### PR DESCRIPTION
Noticed https://github.com/IDI-Systems/acre2/pull/1335 had config error but no message


Can repoduce with open `class x {`

- With semicolon as last char in file
```
class CfgVehicles {
    class a {
};
```

```
ERROR panicked at libs\config\src\analyze\codes\mod.rs:54:40:
index out of bounds: the len is 1912 but the index is 1912
```

- With newline or comment at eof
```
class CfgVehicles {
    class a {
};
//test
```

No error messages, ends with ` INFO Rapified x addon configs`
but it returns error code 1 and `-vv` shows `TRACE phase: pre_build (Rapifier) (failed)`


PR makes it return an error on EOF error
```
error[CCHU]: found end of input but expected one of "8", "Y"....
```
