### PR TITLE
parse: fix `//` inside single quote strings

### DIFF
--- a/libs/preprocessor/tests/bootstrap.rs
+++ b/libs/preprocessor/tests/bootstrap.rs
@@ -50,6 +50,7 @@ bootstrap!(addon_in_ifdef);
 bootstrap!(cba_is_admin);
 bootstrap!(cba_multiline);
 bootstrap!(comment_edgecase);
+bootstrap!(comment_in_quote);
 bootstrap!(define_builtin);
 bootstrap!(define_function_empty);
 bootstrap!(define_function_multiline);

--- a/libs/preprocessor/tests/bootstrap/comment_in_quote/expected.hpp
+++ b/libs/preprocessor/tests/bootstrap/comment_in_quote/expected.hpp
@@ -1,0 +1,12 @@
+url1 = 'http://www.zombo.com';
+url2 = "http://www.zombo.com";
+
+"'//'
+'// a
+""'//""
+"
+
+'"//"
+"// c
+''"//''
+'

--- a/libs/preprocessor/tests/bootstrap/comment_in_quote/source.hpp
+++ b/libs/preprocessor/tests/bootstrap/comment_in_quote/source.hpp
@@ -1,0 +1,12 @@
+url1 = 'http://www.zombo.com';// "Great Site"
+url2 = "http://www.zombo.com";
+
+"'//'
+'// a
+""'//""
+"// b
+
+'"//"
+"// c
+''"//''
+'// d


### PR DESCRIPTION
e.g. url inside single quote string
```
error[SPE1]: invalid token
1 │ _ctrl htmlLoad 'https://zombo.com/';
  │                      ^ invalid token
```
the `//` was treated as a comment and the rest of line was cutoff (so just `'https:`)

I am not positive on my change to parsing logic and changes should be carefully looked it,
but it seems to pass all tests