### PR TITLE
Adds link to workshop page for the missing mod on error: workshop mod not found

### DIFF
--- a/bin/src/commands/launch/error/bcle3_workshop_mod_not_found.rs
+++ b/bin/src/commands/launch/error/bcle3_workshop_mod_not_found.rs
@@ -16,7 +16,7 @@ impl Code for WorkshopModNotFound {
     }
 
     fn help(&self) -> Option<String> {
-        Some("HEMTT does not subscribe to mods, you must subscribe in Steam and allow it to download.".to_owned())
+        Some(format!("HEMTT does not subscribe to mods, you must subscribe in Steam and allow it to download. \nWorkshop link: https://steamcommunity.com/sharedfiles/filedetails/?id={}", self.id).to_owned())
     }
 
     fn diagnostic(&self) -> Option<Diagnostic> {


### PR DESCRIPTION
Adds a direct link in the error message that a workshop mod is not found. Makes it easier to quickly open and subscribe to the missing mod. 
Suggested by OverlordZorn on discord. 

Before:
![billede](https://github.com/user-attachments/assets/1089b87b-608c-46ce-90d3-05af23605cbb)

After:
![image](https://github.com/user-attachments/assets/92be168c-851e-4fcc-b939-1341dd559dc4)
