### PR TITLE
workspace: fix span extraction with length of 1

### DIFF
--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashMap, ops::Range, rc::Rc, sync::Arc};
+use tracing::warn;
 
 use crate::{
     position::{LineCol, Position},
@@ -272,7 +273,8 @@ impl Processed {
     #[must_use]
     /// Return a string with the source from the span
     pub fn extract(&self, span: Range<usize>) -> Arc<str> {
-        if span.start + 1 == span.end {
+        if span.start == span.end {
+            warn!("tried to extract an invalid span");
             return Arc::from("");
         }
         let mut real_start = 0;


### PR DESCRIPTION
fixes
`if (true) then { a } else { b };`
```
push true
callFunction if;
push [{},{}]
callOperator then
```

I couldn't find any examples of the `warn` triggering, so I don't see any harm in adding it