### PR TITLE
sqf: fix serilizing empty code

### DIFF
--- a/libs/sqf/src/compiler/mod.rs
+++ b/libs/sqf/src/compiler/mod.rs
@@ -78,7 +78,11 @@ impl Statements {
                 .expect("first statement not in mapping");
             let offset = start.processed_start().offset() as u32;
             let source = processed.extract(self.span.clone());
-            let length = source.len() as u32;
+            let length = if self.content.is_empty() {
+                0
+            } else {
+                source.len() as u32
+            };
             CodePointer::Source { offset, length }
         };
         Ok(Instructions {


### PR DESCRIPTION
maybe alt to #754
I think we still need https://github.com/BrettMayson/HEMTT/pull/748 for extracting vars that are single chars

cba/ace builds using this seem to work fine, but I don't have full confidence
