### PR TITLE
utils: fix sqf case util when code doesn't end with whitespace

### DIFF
--- a/bin/src/utils/sqf/case.rs
+++ b/bin/src/utils/sqf/case.rs
@@ -165,6 +165,8 @@ fn file(file: &Path) -> Result<bool, Error> {
             }
         }
     }
+    // flush buffer if we ended on non-whitepsace
+    check_buffer(&mut out, &mut buffer, &wiki);
 
     // Write the file
     if content != out {


### PR DESCRIPTION
flush buffer if file ends on a char (no whitespace/newline)

e.g. https://github.com/BourbonWarfare/POTATO/blob/master/addons/bodyCleanup/functions/fnc_getPlayerViewCones.sqf#L48
it would delete the last `_viewCones`