### PR TITLE
sqf: Compile relative arma file paths

### DIFF
--- a/libs/sqf/src/compiler/mod.rs
+++ b/libs/sqf/src/compiler/mod.rs
@@ -41,7 +41,7 @@ impl Statements {
             file_names: processed
                 .sources()
                 .iter()
-                .map(|(s, _)| s.as_str().into())
+                .map(|(s, _)| s.as_virtual_str().into())
                 .collect(),
         })
     }

--- a/libs/workspace/src/path.rs
+++ b/libs/workspace/src/path.rs
@@ -128,6 +128,22 @@ impl WorkspacePath {
     }
 
     #[must_use]
+    /// Get the arma path as a [`String`]
+    pub fn as_virtual_str(&self) -> String {
+        let mut path = self.data.path.as_str().replace('\\', "/");
+        let path_lower = path.to_lowercase();
+        if let Some((base, root)) =
+            self.data.workspace.pointers.iter().find(|(_, vfs)| {
+                path_lower.starts_with(&format!("{}/", vfs.as_str().to_lowercase()))
+            })
+        {
+            path = format!("{}{}", base, &path[root.as_str().len()..].to_string());
+        }
+
+        path
+    }
+
+    #[must_use]
     /// Get the parent of the path
     pub fn parent(&self) -> Self {
         Self {


### PR DESCRIPTION
compiled file paths should be relative to arma not the project

e.g.
![image](https://github.com/user-attachments/assets/91705400-1626-486a-9414-e52cd61f8fb1)
before: `/addons/main/test.sqf`
after: `/a/b/addons/main/test.sqf`
