### PR TITLE
sqf: Lint for `if ! else`

### DIFF
--- a/libs/sqf/src/analyze/lints/s10_if_not_else.rs
+++ b/libs/sqf/src/analyze/lints/s10_if_not_else.rs
@@ -1,0 +1,136 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{lint::{AnyLintRunner, Lint, LintRunner}, reporting::{Code, Codes, Diagnostic, Processed, Severity}};
+
+use crate::{analyze::SqfLintData, BinaryCommand, Expression, UnaryCommand};
+
+crate::lint!(LintS10IfNotElse);
+
+impl Lint<SqfLintData> for LintS10IfNotElse {
+    fn ident(&self) -> &str {
+        "if_not_else"
+    }
+
+    fn sort(&self) -> u32 {
+        80
+    }
+
+    fn description(&self) -> &str {
+        "Checks for unneeded not"
+    }
+
+    fn documentation(&self) -> &str {
+r"### Example
+
+**Incorrect**
+```sqf
+if (!alive player) then { player } else { objNull };
+```
+**Correct**
+```sqf
+if (alive player) then { objNull } else { player };
+```
+
+### Explanation
+
+"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<SqfLintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<SqfLintData> for Runner {
+                type Target = crate::Expression;
+    
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Self::Target,
+        _data: &SqfLintData,
+    ) -> Codes {
+
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        if let Expression::BinaryCommand(BinaryCommand::Named(name), if_cmd, code, _) = target {
+            if name.to_lowercase() == "then" {
+                let Expression::UnaryCommand(UnaryCommand::Named(_), condition, _) = &**if_cmd else {
+                    return Vec::new();
+                };
+                if let Expression::BinaryCommand(BinaryCommand::Else, _, _, _) = &**code {
+                    if let Expression::UnaryCommand(UnaryCommand::Not, _, _) = &**condition
+                    {
+                    return vec![Arc::new(CodeS10IfNot::new(
+                            if_cmd.span(),
+                            "if ! else - consider removing not and swapping else".to_string(),
+                            processed,
+                            config.severity(),
+                        ))];
+                    }
+                }
+            }
+        }
+        Vec::new()
+    }
+}
+
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS10IfNot {
+    span: Range<usize>,
+    problem: String, //todo
+
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS10IfNot {
+    fn ident(&self) -> &'static str {
+        "L-S10"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/analysis/sqf.html#if_not_else")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        self.problem.clone()
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS10IfNot {
+    #[must_use]
+    pub fn new(span: Range<usize>, problem: String, processed: &Processed, severity: Severity) -> Self {
+        Self {
+            span,
+            problem,
+
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::new_for_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -75,3 +75,4 @@ analyze!(s06_find_in_str);
 analyze!(s07_select_parse_number);
 analyze!(s08_format_args);
 analyze!(s09_banned_command);
+analyze!(s10_if_not_else);

--- a/libs/sqf/tests/lints/s10_if_not_else/source.sqf
+++ b/libs/sqf/tests/lints/s10_if_not_else/source.sqf
@@ -1,0 +1,2 @@
+if (!y) then { skipTime 10 };
+if (!alive player) then { player } else { objNull };

--- a/libs/sqf/tests/lints/s10_if_not_else/stdout.ansi
+++ b/libs/sqf/tests/lints/s10_if_not_else/stdout.ansi
@@ -1,0 +1,6 @@
+[0m[1m[38;5;14mhelp[L-S10][0m[1m: if ! else - consider removing not and swapping else[0m
+  [0m[36m┌─[0m source.sqf:2:1
+  [0m[36m│[0m
+[0m[36m2[0m [0m[36m│[0m [0m[36mif[0m (!alive player) then { player } else { objNull };
+  [0m[36m│[0m [0m[36m^^[0m [0m[36mif ! else - consider removing not and swapping else[0m
+


### PR DESCRIPTION
just an idea, probably not worth the effort to gain a tiny bit of speed, also might hurt code flow//readability?

Add suggestion to eliminate `!` when there is an `else`
e.g.
```
        if !(_target in allUnitsUAV) then {
            _target = effectiveCommander _target;
        } else {
            _target = objNull;
        };
```
```
47 │         if !(_target in allUnitsUAV) then {
   │         ^^ if ! else - consider removing not and swapping else
```