### PR TITLE
sqf: Fix sqfc byte offset

### DIFF
--- a/libs/sqf/src/compiler/mod.rs
+++ b/libs/sqf/src/compiler/mod.rs
@@ -74,10 +74,7 @@ impl Statements {
                 ctx.add_constant(Constant::String(self.source.clone()))?,
             ))
         } else {
-            let start = processed
-                .mapping(self.span.start)
-                .expect("first statement not in mapping");
-            let offset = start.processed_start().offset() as u32;
+            let offset = processed.get_byte_offset(self.span.start);
             let source = processed.extract(self.span.clone());
             let length = if self.content.is_empty() {
                 0
@@ -102,8 +99,9 @@ pub fn location_to_source(processed: &Processed, location: &Range<usize>) -> Sou
     let map = processed.mapping(location.start).expect(
         "location not in mapping, this should not happen as the location is from the processed file",
     ).original();
+    let offset = processed.get_byte_offset(location.start);
     SourceInfo {
-        offset: location.start as u32,
+        offset: offset,
         file_index: processed
             .sources()
             .iter()

--- a/libs/sqf/src/compiler/mod.rs
+++ b/libs/sqf/src/compiler/mod.rs
@@ -101,7 +101,7 @@ pub fn location_to_source(processed: &Processed, location: &Range<usize>) -> Sou
     ).original();
     let offset = processed.get_byte_offset(location.start);
     SourceInfo {
-        offset: offset,
+        offset,
         file_index: processed
             .sources()
             .iter()

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -259,10 +259,11 @@ impl Processed {
     }
 
     #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     /// Get offset as number of raw bytes into the output string
     pub fn get_byte_offset(&self, offset: usize) -> u32 {
-        let ret: usize = self.output.chars().take(offset).map(|c| c.len_utf8()).sum();
-        return ret as u32;
+        let ret: usize = self.output.chars().take(offset).map(char::len_utf8).sum();
+        ret as u32
     }
 
     #[must_use]

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -259,6 +259,13 @@ impl Processed {
     }
 
     #[must_use]
+    /// Get offset as number of raw bytes into the output string
+    pub fn get_byte_offset(&self, offset: usize) -> u32 {
+        let ret: usize = self.output.chars().take(offset).map(|c| c.len_utf8()).sum();
+        return ret as u32;
+    }
+
+    #[must_use]
     /// Returns the warnings
     pub fn warnings(&self) -> &[Arc<dyn Code>] {
         &self.warnings


### PR DESCRIPTION
Fixes two problems with sqfc offsets
Shouldn't be any functionality change, just effects arma errors and debugging.

- It would use the macro's start location

```
from sqf:
#define IS_META_SYS(VAR,TYPE) (if (isNil {VAR}) then {false} else {(VAR) isEqualType TYPE})
#define IS_STRING(VAR)   IS_META_SYS(VAR,"STRING")  

before (nonsense because it's using the index of start of macro for both sub blocks):
push [{(if (},{(if (isNil {_pos}) then {fa}]
after:
push [{false},{(_pos) isEqualType "STRING"}]
```

- Unicode would cause problems, as arma seems to expect bytes

e.g. the `#` is in the wrong location
before:
![before](https://github.com/user-attachments/assets/745d8a69-e647-4a7c-82e1-4634810c0355)
after:
![after](https://github.com/user-attachments/assets/5f7cc8ae-8ed3-4981-8287-bc16cd072116)
