### PR TITLE
sqf: Don't allow trailing commas in arrays

### DIFF
--- a/libs/sqf/src/parser/mod.rs
+++ b/libs/sqf/src/parser/mod.rs
@@ -97,7 +97,6 @@ fn statements<'a>(
             let array = expression
                 .clone()
                 .separated_by(just(Token::Control(Control::Separator)))
-                .allow_trailing()
                 .map_with_span(Expression::Array)
                 .delimited_by(array_open, array_close);
 

--- a/libs/sqf/tests/lints/s05_if_assign/source.sqf
+++ b/libs/sqf/tests/lints/s05_if_assign/source.sqf
@@ -5,5 +5,5 @@ if (alivePlayer) then {
 };
 private _limbs = [
     if (alive player) then { "torso" } else { "legs" },
-    if (alive player) then { "torso" } else { "legs" },
+    if (alive player) then { "torso" } else { "legs" }
 ];

--- a/libs/sqf/tests/lints/s05_if_assign/stdout.ansi
+++ b/libs/sqf/tests/lints/s05_if_assign/stdout.ansi
@@ -34,7 +34,7 @@
 [0m[1m[38;5;14mhelp[L-S05][0m[1m: assignment to if can be replaced with select[0m
   [0m[36m┌─[0m source.sqf:8:5
   [0m[36m│[0m
-[0m[36m8[0m [0m[36m│[0m     [0m[36mif (alive player) then { "torso" } else { "legs" }[0m,
+[0m[36m8[0m [0m[36m│[0m     [0m[36mif (alive player) then { "torso" } else { "legs" }[0m
   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse select[0m
   [0m[36m│[0m
   [0m[36m=[0m [36mnote[0m: the if and else blocks only return constant values


### PR DESCRIPTION
Trailing comma in arrays cause script errors (when using non-compiled//filepatching)
```
Error in expression <x = [1,2,]>
Error position: <]>
Error Missing [
```