### PR TITLE
sqf: enable optimizer by default

### DIFF
--- a/bin/src/commands/build.rs
+++ b/bin/src/commands/build.rs
@@ -42,12 +42,6 @@ pub fn add_args(cmd: Command) -> Command {
             .help("Use ArmaScriptCompiler instead of HEMTT's SQF compiler")
             .action(ArgAction::SetTrue),
     )
-    .arg(
-        clap::Arg::new("expopti")
-            .long("expopti")
-            .help("Use SQFC Optimizer")
-            .action(ArgAction::SetTrue),
-    )
 }
 
 #[must_use]
@@ -99,7 +93,6 @@ pub fn executor(ctx: Context, matches: &ArgMatches) -> Executor {
     let mut executor = Executor::new(ctx);
 
     let use_asc = matches.get_one::<bool>("asc") == Some(&true);
-    let use_optimizer = matches.get_one::<bool>("expopti") == Some(&true);
 
     executor.collapse(Collapse::No);
 
@@ -107,7 +100,7 @@ pub fn executor(ctx: Context, matches: &ArgMatches) -> Executor {
     if matches.get_one::<bool>("no-rap") != Some(&true) {
         executor.add_module(Box::<Rapifier>::default());
     }
-    executor.add_module(Box::new(SQFCompiler::new(!use_asc, use_optimizer)));
+    executor.add_module(Box::new(SQFCompiler::new(!use_asc)));
     #[cfg(not(target_os = "macos"))]
     if use_asc {
         executor.add_module(Box::<ArmaScriptCompiler>::default());

--- a/bin/src/commands/dev.rs
+++ b/bin/src/commands/dev.rs
@@ -53,12 +53,6 @@ pub fn add_args(cmd: Command) -> Command {
             .action(ArgAction::SetTrue),
     )
     .arg(
-        clap::Arg::new("expopti")
-            .long("expopti")
-            .help("Use SQFC Optimizer")
-            .action(ArgAction::SetTrue),
-    )
-    .arg(
         clap::Arg::new("no-rap")
             .long("no-rap")
             .help("Do not rapify (cpp, rvmat)")
@@ -137,7 +131,6 @@ pub fn context(
     }
 
     let use_asc = matches.get_one::<bool>("asc") == Some(&true);
-    let use_optimizer = matches.get_one::<bool>("expopti") == Some(&true);
 
     let mut executor = Executor::new(ctx);
 
@@ -147,7 +140,7 @@ pub fn context(
     if rapify && matches.get_one::<bool>("no-rap") != Some(&true) {
         executor.add_module(Box::<Rapifier>::default());
     }
-    executor.add_module(Box::new(SQFCompiler::new(!use_asc, use_optimizer)));
+    executor.add_module(Box::new(SQFCompiler::new(!use_asc)));
     #[cfg(not(target_os = "macos"))]
     if use_asc {
         executor.add_module(Box::<ArmaScriptCompiler>::default());

--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -136,11 +136,7 @@ impl Module for SQFCompiler {
         info!(
             "{} {} sqf files",
             if self.compile {
-                if self.optimize {
-                    "Compiled [Optimized]"
-                } else {
-                    "Compiled"
-                }
+                "Compiled"
             } else {
                 "Validated"
             },

--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -19,16 +19,14 @@ use super::Module;
 #[derive(Default)]
 pub struct SQFCompiler {
     pub compile: bool,
-    pub optimize: bool,
     pub database: Option<Arc<Database>>,
 }
 
 impl SQFCompiler {
     #[must_use]
-    pub const fn new(compile: bool, optimize: bool) -> Self {
+    pub const fn new(compile: bool) -> Self {
         Self {
             compile,
-            optimize,
             database: None,
         }
     }
@@ -102,8 +100,7 @@ impl Module for SQFCompiler {
                         if !codes.failed() {
                             if self.compile {
                                 let mut out = entry.with_extension("sqfc")?.create_file()?;
-                                let sqf_to_write = if self.optimize { sqf.optimize() } else { sqf };
-                                sqf_to_write.compile_to_writer(&processed, &mut out)?;
+                                sqf.optimize().compile_to_writer(&processed, &mut out)?;
                             }
                             counter.fetch_add(1, Ordering::Relaxed);
                         }

--- a/bin/tests/build.rs
+++ b/bin/tests/build.rs
@@ -15,6 +15,5 @@ fn build_alpha() {
 fn build_bravo() {
     std::env::set_current_dir(format!("{}/tests/bravo", env!("CARGO_MANIFEST_DIR"))).unwrap();
     hemtt::execute(&cli().get_matches_from(vec!["hemtt", "script", "test"])).unwrap();
-    hemtt::execute(&cli().get_matches_from(vec!["hemtt", "release", "--in-test", "--expopti"]))
-        .unwrap();
+    hemtt::execute(&cli().get_matches_from(vec!["hemtt", "release", "--in-test"])).unwrap();
 }


### PR DESCRIPTION
Hasn't been any problems I've seen.

I think there is no reason to have an option not to use the optimizer, if we ever add any new optimizations we are unsure of, they should be behind their own --exp flag for testing