### PR TITLE
sqf: Add lint for vars that are ALL_CAPS and not a macro

### DIFF
--- a/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
+++ b/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
@@ -1,0 +1,128 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{analyze::SqfLintData, Expression};
+
+crate::lint!(LintS17VarAllCaps);
+
+impl Lint<SqfLintData> for LintS17VarAllCaps {
+    fn ident(&self) -> &str {
+        "var_all_caps"
+    }
+
+    fn sort(&self) -> u32 {
+        170
+    }
+
+    fn description(&self) -> &str {
+        "Checks for global variables that are ALL_CAPS and may actually be a undefined macro"
+    }
+
+    fn documentation(&self) -> &str {
+        r"### Example
+
+**Incorrect**
+```sqf
+private _z = _y + DO_NOT_EXIST;
+```
+"
+    }
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help().with_enabled(false)
+    }
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<SqfLintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<SqfLintData> for Runner {
+    type Target = crate::Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Self::Target,
+        _data: &SqfLintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        let Expression::Variable(var, span) = target else {
+            return Vec::new();
+        };
+        if var.starts_with('_') || &var.to_ascii_uppercase() != var || var == "SLX_XEH_COMPILE_NEW" {
+            return Vec::new();
+        }
+        if let Some(toml::Value::Array(ignore)) = config.option("ignore") {
+            if ignore.iter().any(|i| i.as_str().unwrap_or_default() == var) {
+                return Vec::new();
+            }
+        }
+        vec![Arc::new(CodeS17VarAllCaps::new(
+            span.clone(),
+            var.clone(),
+            processed,
+            config.severity(),
+        ))]
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS17VarAllCaps {
+    span: Range<usize>,
+    var: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS17VarAllCaps {
+    fn ident(&self) -> &'static str {
+        "L-S17"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/analysis/sqf.html#var_all_caps")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        // print var again here if it's part of a macro
+        format!("Var all caps: {}",self.var)
+    }
+
+    fn label_message(&self) -> String {
+        String::new()
+    }
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS17VarAllCaps {
+    #[must_use]
+    pub fn new(span: Range<usize>, var: String, processed: &Processed, severity: Severity) -> Self {
+        Self {
+            span,
+            var,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::new_for_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -81,3 +81,4 @@ analyze!(s07_select_parse_number);
 analyze!(s08_format_args);
 analyze!(s09_banned_command);
 analyze!(s11_if_not_else);
+analyze!(s17_var_all_caps);

--- a/libs/sqf/tests/lints/project_tests.toml
+++ b/libs/sqf/tests/lints/project_tests.toml
@@ -8,3 +8,9 @@ options.ignore = [
 
 [lints.sqf]
 if_not_else = true
+
+[lints.sqf.var_all_caps]
+enabled = true
+options.ignore = [
+    "AM_IGNORED",
+]

--- a/libs/sqf/tests/lints/s17_var_all_caps/source.sqf
+++ b/libs/sqf/tests/lints/s17_var_all_caps/source.sqf
@@ -1,0 +1,5 @@
+#define EXIST 1
+
+private _x = 1 + EXIST;
+private _y = _x + AM_IGNORED;
+private _z = _y + DO_NOT_EXIST;

--- a/libs/sqf/tests/lints/s17_var_all_caps/stdout.ansi
+++ b/libs/sqf/tests/lints/s17_var_all_caps/stdout.ansi
@@ -1,0 +1,6 @@
+[0m[1m[38;5;14mhelp[L-S17][0m[1m: Var all caps: DO_NOT_EXIST[0m
+  [0m[36m┌─[0m source.sqf:5:19
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m private _z = _y + [0m[36mDO_NOT_EXIST[0m;
+  [0m[36m│[0m                   [0m[36m^^^^^^^^^^^^[0m
+


### PR DESCRIPTION
Checks for global variables that are ALL_CAPS and may actually be a undefined macro

ref https://github.com/acemod/ACE3/pull/10389
I think default off is a best as some mods use all caps in their code style
e.g. CBA/ACRE `SLX_XEH_MACHINE` `ACRE_SPOKEN_LANGUAGES` `ACRE_IS_SPECTATOR`
