### PR TITLE
sqf: optimizer should trace only when testing

### DIFF
--- a/libs/sqf/src/compiler/optimizer/mod.rs
+++ b/libs/sqf/src/compiler/optimizer/mod.rs
@@ -199,6 +199,7 @@ impl Expression {
                     }
                     BinaryCommand::Else => {
                         if let (Self::Code(_), Self::Code(_)) = (&left_o, &right_o) {
+                            #[cfg(debug_assertions)]
                             trace!("optimizing [B:{}] => ConsumeableArray", op_type.as_str());
                             return Self::ConsumeableArray(vec![left_o, right_o], range.clone());
                         }
@@ -259,19 +260,23 @@ impl Expression {
     fn get_consumable_array(&self, direct: bool, op: &String) -> Option<Self> {
         if let Self::Array(array, range) = &self {
             if !self.is_constant() {
-                // println!("debug: not const {op}");
+                #[cfg(debug_assertions)]
+                trace!("not constant {op}");
                 return None;
             }
             if array.is_empty() {
-                println!("debug: pointless to optimize {op}");
+                #[cfg(debug_assertions)]
+                trace!("pointless to optimize {op}");
                 return None;
             }
             if direct {
+                #[cfg(debug_assertions)]
                 trace!("optimizing [{op}]'s arg => ConsumeableArray");
                 Some(Self::ConsumeableArray(array.clone(), range.clone()))
             } else {
-                // make a copy of the array so the original cannot be modified
+                #[cfg(debug_assertions)]
                 trace!("optimizing [{op}]'s arg => +ConsumeableArray (copy)");
+                // make a copy of the array so the original cannot be modified
                 Some(Self::UnaryCommand(
                     UnaryCommand::Plus,
                     Box::new(Self::ConsumeableArray(array.clone(), range.clone())),
@@ -295,6 +300,7 @@ impl Expression {
         if let Self::String(right_string, _, ref right_wrapper) = right {
             if right_string.is_ascii() {
                 let new_string = op(right_string.as_ref());
+                #[cfg(debug_assertions)]
                 trace!(
                     "optimizing [U:{}] ({}) => {}",
                     op_type.as_str(),
@@ -329,6 +335,7 @@ impl Expression {
         if let Self::Number(crate::Scalar(right_number), _) = right {
             let new_number = op(*right_number);
             if new_number.is_finite() {
+                #[cfg(debug_assertions)]
                 trace!(
                     "optimizing [U:{}] ({}) => {}",
                     op_type.as_str(),
@@ -361,6 +368,7 @@ impl Expression {
             if let Self::String(right_string, _, ref right_wrapper) = right {
                 if right_string.is_ascii() && left_string.is_ascii() {
                     let new_string = op(left_string.as_ref(), right_string.as_ref());
+                    #[cfg(debug_assertions)]
                     trace!(
                         "optimizing [B:{}] ({}) => {}",
                         op_type.as_str(),
@@ -398,6 +406,7 @@ impl Expression {
             if let Self::Number(crate::Scalar(right_number), _) = right {
                 let new_number = op(*left_number, *right_number);
                 if new_number.is_finite() {
+                    #[cfg(debug_assertions)]
                     trace!(
                         "optimizing [B:{}] ({}) => {}",
                         op_type.as_str(),


### PR DESCRIPTION
Floods the logs with traces which will mean nothing to anyone not developing HEMTT

Now the trace! is only added with `debug_assertions` (testing and building locally)