### PR TITLE
workspace: fix pointer scanning, add duplicate prefix error

### DIFF
--- a/libs/common/src/prefix.rs
+++ b/libs/common/src/prefix.rs
@@ -117,6 +117,9 @@ pub enum Error {
     #[error("Invalid prefix: {0}")]
     /// Invalid prefix
     InvalidPrefix(String),
+    #[error("Duplicate prefix: {0}")]
+    /// Duplicate prefix
+    DuplicatePrefix(String),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Checks `/include/`, `/optionals/`, `/addons/` for prefix files instead of `/`

Adds a new error if there are any duplicate prefix files