### PR TITLE
config: file type check ignores classes

### DIFF
--- a/libs/config/src/analyze/lints/c11_file_type.rs
+++ b/libs/config/src/analyze/lints/c11_file_type.rs
@@ -26,11 +26,11 @@ impl Lint<LintData> for LintC11FileType {
     fn documentation(&self) -> &'static str {
 r#"### Configuration
 
-- **allow_no_extension**: Allow properties to not have a file extension, default is `true`.
+- **allow_no_extension**: Allow properties to not have a file extension, default is `false`.
 
 ```toml
 [lints.config.file_type]
-options.allow_no_extension = false
+options.allow_no_extension = true
 ```
 
 ### Example
@@ -114,7 +114,7 @@ impl LintRunner<LintData> for Runner {
         let allow_no_extension = if let Some(toml::Value::Boolean(allow_no_extension)) = config.option("allow_no_extension") {
             *allow_no_extension
         } else {
-            true
+            false
         };
         // Arrays
         if let Value::Array(values) = value {
@@ -138,6 +138,10 @@ impl LintRunner<LintData> for Runner {
 
 fn check(name: &str, value: &Str, allow_no_extension: bool, processed: &Processed, config: &LintConfig) -> Option<Arc<dyn Code>> {
     let value_str = value.value();
+    // Skip if it contains no backslashes, probably a class name
+    if !value_str.contains('\\') {
+        return None;
+    }
     if name == "sound" && value_str.starts_with("db") {
         return None;
     }

--- a/libs/config/tests/lints/c11_file_type.hpp
+++ b/libs/config/tests/lints/c11_file_type.hpp
@@ -1,7 +1,9 @@
 class CfgVehicles {
     class MyVehicle {
-        model = "test.p3d";
-        editorPreview = "test.jgp";
-        wounds[] = {"would1.pac", "wound2.paa", "wound3.png"};
+        model = "x\mod\test.p3d";
+        uimodel = "x\mod\test_no_path";
+        editorPreview = "x\mod\test.jgp";
+        wounds[] = {"x\mod\would1.pac", "x\mod\wound2.paa", "x\mod\wound3.png"};
+        modelspecial = "class_name";
     };
 };

--- a/libs/config/tests/snapshots/lints__config_error_c11_file_type.snap
+++ b/libs/config/tests/snapshots/lints__config_error_c11_file_type.snap
@@ -2,19 +2,26 @@
 source: libs/config/tests/lints.rs
 expression: lint(stringify! (c11_file_type))
 ---
-[0m[1m[38;5;11mwarning[L-C11UE][0m[1m: a property that references a file has an unusual file type[0m
-  [0m[36m┌─[0m c11_file_type.hpp:4:31
+[0m[1m[38;5;11mwarning[L-C11ME][0m[1m: a property that references a file is missing a file extension[0m
+  [0m[36m┌─[0m c11_file_type.hpp:4:20
   [0m[36m│[0m
-[0m[36m4[0m [0m[36m│[0m         editorPreview = "test.[0m[33mjgp[0m";
-  [0m[36m│[0m                               [0m[33m^^^[0m [0m[33munusual file type[0m
+[0m[36m4[0m [0m[36m│[0m         uimodel = "[0m[33mx\mod\test_no_path[0m";
+  [0m[36m│[0m                    [0m[33m^^^^^^^^^^^^^^^^^^[0m [0m[33mmissing file extension[0m
+
+
+[0m[1m[38;5;11mwarning[L-C11UE][0m[1m: a property that references a file has an unusual file type[0m
+  [0m[36m┌─[0m c11_file_type.hpp:5:37
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m         editorPreview = "x\mod\test.[0m[33mjgp[0m";
+  [0m[36m│[0m                                     [0m[33m^^^[0m [0m[33munusual file type[0m
   [0m[36m│[0m
   [0m[36m=[0m [36mnote[0m: expected file type jpg
 
 
 [0m[1m[38;5;11mwarning[L-C11UE][0m[1m: a property that references a file has an unusual file type[0m
-  [0m[36m┌─[0m c11_file_type.hpp:5:57
+  [0m[36m┌─[0m c11_file_type.hpp:6:75
   [0m[36m│[0m
-[0m[36m5[0m [0m[36m│[0m         wounds[] = {"would1.pac", "wound2.paa", "wound3.[0m[33mpng[0m"};
-  [0m[36m│[0m                                                         [0m[33m^^^[0m [0m[33munusual file type[0m
+[0m[36m6[0m [0m[36m│[0m         wounds[] = {"x\mod\would1.pac", "x\mod\wound2.paa", "x\mod\wound3.[0m[33mpng[0m"};
+  [0m[36m│[0m                                                                           [0m[33m^^^[0m [0m[33munusual file type[0m
   [0m[36m│[0m
   [0m[36m=[0m [36mnote[0m: expected file type paa


### PR DESCRIPTION
- Assume that values without `\` are classes
- Change `allow_no_extension` to false by default
- Closes #851, probably