### PR TITLE
config: Skip magwell check if no prefix defined

### DIFF
--- a/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
+++ b/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
@@ -141,6 +141,7 @@ impl LintRunner<LintData> for Runner {
                         continue;
                     };
                     if let Some(project) = project {
+                        if project.prefix().is_empty() { continue; }
                         if !value
                             .to_lowercase()
                             .starts_with(&project.prefix().to_lowercase())


### PR DESCRIPTION
e.g. CBA repo
![image](https://github.com/user-attachments/assets/754e2589-32ea-4c32-94e1-dcefdfa8157c)

this should only be running for magazines that start with `CBA`
So I assume the prefix isn't loaded and is defaulting to "", which matches all mags?