### PR TITLE
Stringtables - Use addon build_data

### DIFF
--- a/arma/src/lib.rs
+++ b/arma/src/lib.rs
@@ -30,7 +30,7 @@ fn init() -> Extension {
                 && len_buf != [255u8; 4]
             {
                 let len = u32::from_le_bytes(len_buf);
-                println!("Receiving: {}", len);
+                println!("Receiving: {len}");
                 let mut buf = vec![0u8; len as usize];
                 socket.read_exact(&mut buf).unwrap();
                 let buf = String::from_utf8(buf).unwrap();
@@ -43,12 +43,12 @@ fn init() -> Extension {
                     },
                     toarma::Message::Photoshoot(photoshoot) => match photoshoot {
                         toarma::Photoshoot::Weapon(weapon) => {
-                            println!("Weapon: {}", weapon);
+                            println!("Weapon: {weapon}");
                             ctx.callback_data("hemtt_photoshoot", "weapon_add", weapon.clone())
                                 .unwrap();
                         }
                         toarma::Photoshoot::Preview(class) => {
-                            println!("Preview: {}", class);
+                            println!("Preview: {class}");
                             ctx.callback_data("hemtt_photoshoot", "preview_add", class.clone())
                                 .unwrap();
                         }
@@ -89,7 +89,10 @@ fn log(ctx: Context, level: String, message: String) {
         "info" => fromarma::Level::Info,
         "warn" => fromarma::Level::Warn,
         "error" => fromarma::Level::Error,
-        _ => fromarma::Level::Info,
+        _ => {
+            println!("Unknown log level: {}", level);
+            fromarma::Level::Info
+        }
     };
     let Some(sender) = ctx.global().get::<std::sync::mpsc::Sender<Message>>() else {
         println!("`log` called without a sender");
@@ -100,9 +103,8 @@ fn log(ctx: Context, level: String, message: String) {
 
 fn send(message: fromarma::Message, socket: &mut Stream) {
     let message = serde_json::to_string(&message).unwrap();
-    socket
-        .write_all(&u32::to_le_bytes(message.len() as u32))
-        .unwrap();
+    let len = u32::try_from(message.len()).unwrap();
+    socket.write_all(&u32::to_le_bytes(len)).unwrap();
     socket.write_all(message.as_bytes()).unwrap();
     socket.flush().unwrap();
 }

--- a/bin/src/commands/build.rs
+++ b/bin/src/commands/build.rs
@@ -1,5 +1,3 @@
-use hemtt_common::config::BuildInfo;
-
 use crate::{
     context::{self, Context},
     error::Error,
@@ -84,8 +82,6 @@ pub fn execute(cmd: &Command) -> Result<Report, Error> {
     if !just.is_empty() {
         ctx = ctx.filter(|a, _| just.contains(&a.name().to_lowercase()));
     }
-    let build_info = BuildInfo::new(ctx.config().prefix());
-    let ctx = ctx.with_build_info(build_info);
     let mut executor = executor(ctx, &cmd.build);
 
     if !just.is_empty() {

--- a/bin/src/commands/check.rs
+++ b/bin/src/commands/check.rs
@@ -1,5 +1,3 @@
-use hemtt_common::config::BuildInfo;
-
 use crate::{
     commands::global_modules,
     context::Context,
@@ -41,8 +39,6 @@ pub fn execute(cmd: &Command) -> Result<Report, Error> {
         crate::context::PreservePrevious::Remove,
         true,
     )?;
-    let build_info = BuildInfo::new(ctx.config().prefix()).with_pedantic(cmd.check.pedantic);
-    let ctx = ctx.with_build_info(build_info);
 
     let mut executor = Executor::new(ctx);
     global_modules(&mut executor);

--- a/bin/src/commands/dev.rs
+++ b/bin/src/commands/dev.rs
@@ -1,4 +1,3 @@
-use hemtt_common::config::BuildInfo;
 use hemtt_workspace::addons::Location;
 
 use crate::{
@@ -159,8 +158,6 @@ pub fn context(
         }
     }
 
-    let build_info = BuildInfo::new(ctx.config().prefix());
-    let ctx = ctx.with_build_info(build_info);
     let mut executor = Executor::new(ctx);
     global_modules(&mut executor);
 

--- a/bin/src/commands/localization/coverage.rs
+++ b/bin/src/commands/localization/coverage.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::BufReader};
+use std::collections::HashMap;
 
 use hemtt_stringtable::{Project, Totals};
 use serde::Serialize;
@@ -106,8 +106,7 @@ pub fn coverage(cmd: &Command) -> Result<Report, Error> {
             .join(addon.folder())?
             .join("stringtable.xml")?;
         if stringtable_path.exists()? {
-            let project = match Project::from_reader(BufReader::new(stringtable_path.open_file()?))
-            {
+            let project = match Project::read(stringtable_path) {
                 Ok(project) => project,
                 Err(e) => {
                     error!("Failed to read stringtable for {}", addon.folder());

--- a/bin/src/commands/localization/sort.rs
+++ b/bin/src/commands/localization/sort.rs
@@ -1,6 +1,7 @@
-use std::{io::BufReader, path::PathBuf};
+use std::path::PathBuf;
 
 use hemtt_stringtable::Project;
+use hemtt_workspace::WorkspacePath;
 
 use crate::{context::Context, report::Report, Error};
 
@@ -48,8 +49,7 @@ pub fn sort(cmd: &Command) -> Result<Report, Error> {
             .collect::<Vec<_>>();
         for path in paths {
             if path.exists() {
-                let mut file = std::fs::File::open(&path)?;
-                match Project::from_reader(BufReader::new(&mut file)) {
+                match Project::read(WorkspacePath::slim_file(path.clone())?) {
                     Ok(mut project) => {
                         if !cmd.only_lang {
                             project.sort();

--- a/bin/src/commands/release.rs
+++ b/bin/src/commands/release.rs
@@ -1,5 +1,3 @@
-use hemtt_common::config::BuildInfo;
-
 use crate::{context::Context, error::Error, modules::Sign, report::Report};
 
 use super::build;
@@ -78,8 +76,6 @@ pub fn execute(cmd: &Command) -> Result<Report, Error> {
         crate::context::PreservePrevious::Remove,
         true,
     )?;
-    let build_info = BuildInfo::new(ctx.config().prefix()).with_release(true);
-    let ctx = ctx.with_build_info(build_info);
     let mut executor = build::executor(ctx, &cmd.build);
 
     if !cmd.release.no_sign && executor.ctx().config().hemtt().release().sign() {

--- a/bin/src/context.rs
+++ b/bin/src/context.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use hemtt_common::config::{BuildInfo, ProjectConfig};
+use hemtt_common::config::ProjectConfig;
 use hemtt_workspace::{addons::Addon, LayerType, Workspace, WorkspacePath};
 
 use crate::error::Error;
@@ -35,7 +35,6 @@ pub struct Context {
     tmp: PathBuf,
     profile: PathBuf,
     state: Arc<State>,
-    build_info: Option<BuildInfo>,
 }
 
 impl Context {
@@ -132,16 +131,7 @@ impl Context {
             tmp,
             profile,
             state: Arc::new(State::default()),
-            build_info: None,
         })
-    }
-
-    #[must_use]
-    pub fn with_build_info(self, build_info: BuildInfo) -> Self {
-        Self {
-            build_info: Some(build_info),
-            ..self
-        }
     }
 
     #[must_use]
@@ -163,11 +153,6 @@ impl Context {
     #[must_use]
     pub const fn config(&self) -> &ProjectConfig {
         &self.config
-    }
-
-    #[must_use]
-    pub const fn build_info(&self) -> Option<&BuildInfo> {
-        self.build_info.as_ref()
     }
 
     #[must_use]

--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -75,6 +75,15 @@ impl Executor {
     /// # Errors
     /// [`Error`] depending on the modules
     pub fn run(&mut self) -> Result<Report, Error> {
+        self.modules.sort_by(|a, b| {
+            if a.name() == "Stringtables" {
+                std::cmp::Ordering::Greater
+            } else if b.name() == "Stringtables" {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
         let mut report = Report::new();
         for stage in self.stages.clone() {
             report.merge(match stage {

--- a/bin/src/modules/new/license.rs
+++ b/bin/src/modules/new/license.rs
@@ -38,10 +38,12 @@ impl Licenses {
             6 => include_str!("licenses/unlicense.txt"),
             _ => unreachable!(),
         };
-
-        Some(license.replace("{author}", author).replace(
-            "{year}",
-            time::OffsetDateTime::now_utc().year().to_string().as_str(),
-        ))
+        #[allow(clippy::literal_string_with_formatting_args)]
+        {
+            Some(license.replace("{author}", author).replace(
+                "{year}",
+                time::OffsetDateTime::now_utc().year().to_string().as_str(),
+            ))
+        }
     }
 }

--- a/bin/src/modules/rapifier.rs
+++ b/bin/src/modules/rapifier.rs
@@ -124,7 +124,7 @@ pub fn rapify(addon: &Addon, path: &WorkspacePath, ctx: &Context) -> Result<Repo
     for warning in processed.warnings() {
         report.push(warning.clone());
     }
-    let configreport = match parse(Some(ctx.config()), ctx.build_info(), &processed) {
+    let configreport = match parse(Some(ctx.config()), &processed) {
         Ok(configreport) => configreport,
         Err(errors) => {
             for e in &errors {
@@ -133,6 +133,17 @@ pub fn rapify(addon: &Addon, path: &WorkspacePath, ctx: &Context) -> Result<Repo
             return Ok(report);
         }
     };
+    addon
+        .build_data()
+        .localizations()
+        .lock()
+        .expect("not poisoned")
+        .extend(
+            configreport
+                .localized()
+                .iter()
+                .map(|(s, p)| (s.to_owned(), p.clone())),
+        );
     configreport.warnings().into_iter().for_each(|e| {
         report.push(e.clone());
     });

--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -90,14 +90,19 @@ impl Module for SQFCompiler {
                 }
                 match hemtt_sqf::parser::run(&database, &processed) {
                     Ok(sqf) => {
-                        let codes = analyze(
+                        let (codes, localizations) = analyze(
                             &sqf,
                             Some(ctx.config()),
-                            ctx.build_info(),
                             &processed,
                             addon.clone(),
                             database.clone(),
                         );
+                        addon
+                            .build_data()
+                            .localizations()
+                            .lock()
+                            .expect("not poisoned")
+                            .extend(localizations);
                         if !codes.failed() {
                             let mut out = entry.with_extension("sqfc")?.create_file()?;
                             sqf.optimize().compile_to_writer(&processed, &mut out)?;

--- a/bin/src/utils/config/inspect.rs
+++ b/bin/src/utils/config/inspect.rs
@@ -81,7 +81,6 @@ pub fn get_report(file: &PathBuf) -> Result<Result<ConfigReport, Vec<Arc<dyn Cod
     let processed = Processor::run(&source).map_err(|e| e.1)?;
     Ok(hemtt_config::parse(
         Some(&ProjectConfig::test_project()),
-        None,
         &processed,
     ))
 }

--- a/hls/src/config/mod.rs
+++ b/hls/src/config/mod.rs
@@ -53,7 +53,7 @@ async fn check_addon(source: WorkspacePath, workspace: EditorWorkspace) {
     let sources = match Processor::run(&source) {
         Ok(processed) => {
             let workspace_files = WorkspaceFiles::new();
-            match hemtt_config::parse(workspace.config().as_ref(), None, &processed) {
+            match hemtt_config::parse(workspace.config().as_ref(), &processed) {
                 Ok(report) => {
                     info!("parsed config for {}", source);
                     for warning in report.warnings() {

--- a/hls/src/files.rs
+++ b/hls/src/files.rs
@@ -31,7 +31,7 @@ impl FileCache {
         self.ropes.entry(url)
     }
 
-    pub async fn on_change<'a>(&self, document: &TextDocumentItem<'a>) {
+    pub async fn on_change(&self, document: &TextDocumentItem<'_>) {
         match &document.text {
             TextInformation::Full(text) => {
                 FileCache::get().insert(document.uri.clone(), Rope::from_str(text));

--- a/hls/src/sqf/mod.rs
+++ b/hls/src/sqf/mod.rs
@@ -37,7 +37,7 @@ impl SqfAnalyzer {
         (*SINGLETON).clone()
     }
 
-    pub async fn on_change<'a>(&self, document: &TextDocumentItem<'a>) {
+    pub async fn on_change(&self, document: &TextDocumentItem<'_>) {
         if !document.uri.path().ends_with(".sqf") {
             return;
         }

--- a/libs/common/src/config/mod.rs
+++ b/libs/common/src/config/mod.rs
@@ -13,7 +13,7 @@ pub use pdrive::PDriveOption;
 pub use project::{
     hemtt::launch::LaunchOptions,
     lint::{LintConfig, LintConfigOverride},
-    BuildInfo, ProjectConfig,
+    ProjectConfig,
 };
 
 fn deprecated(file: &str, key: &str, replacement: &str, info: Option<&str>) {

--- a/libs/common/src/config/project/mod.rs
+++ b/libs/common/src/config/project/mod.rs
@@ -1,10 +1,6 @@
 //! Module for reading HEMTT project files
 
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-    sync::{Arc, Once, RwLock},
-};
+use std::{collections::HashMap, path::PathBuf, sync::Once};
 
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -112,86 +108,6 @@ impl ProjectConfig {
     /// [`crate::error::Error::Prefix`] if the prefix is invalid
     pub fn from_file(path: &std::path::Path) -> Result<Self, Error> {
         ProjectFile::from_file(path)?.try_into()
-    }
-}
-
-#[derive(Debug, Clone)]
-/// Information about the build
-pub struct BuildInfo {
-    /// lowercase, e.g. `$str_prefix_`
-    config_string_prefix: String,
-    /// lowercase, e.g. `str_prefix_`
-    code_string_prefix: String,
-    /// All defined stringtable entries in lowercase, modified during the build
-    stringtable: Arc<RwLock<HashSet<String>>>,
-    /// using `hemtt release`
-    is_release: bool,
-    /// using `hemtt check --pedantic`
-    is_pedantic: bool,
-}
-
-impl BuildInfo {
-    #[must_use]
-    pub fn new(prefix: &String) -> Self {
-        Self {
-            config_string_prefix: format!("$str_{prefix}_").to_lowercase(),
-            code_string_prefix: format!("str_{prefix}_").to_lowercase(),
-            stringtable: Arc::new(RwLock::new(HashSet::new())),
-            is_release: false,
-            is_pedantic: false,
-        }
-    }
-
-    #[must_use]
-    pub const fn is_release(&self) -> bool {
-        self.is_release
-    }
-    #[must_use]
-    pub const fn with_release(mut self, is_release: bool) -> Self {
-        self.is_release = is_release;
-        self
-    }
-    #[must_use]
-    pub const fn is_pedantic(&self) -> bool {
-        self.is_pedantic
-    }
-    #[must_use]
-    pub const fn with_pedantic(mut self, is_pedantic: bool) -> Self {
-        self.is_pedantic = is_pedantic;
-        self
-    }
-    #[must_use]
-    pub const fn stringtable_prefix(&self) -> &String {
-        &self.code_string_prefix
-    }
-    #[must_use]
-    pub fn stringtable_matches_project(&self, str: &str, is_config: bool) -> bool {
-        if is_config {
-            str.to_lowercase().starts_with(&self.config_string_prefix)
-        } else {
-            str.to_lowercase().starts_with(&self.code_string_prefix)
-        }
-    }
-    #[must_use]
-    /// # Panics
-    pub fn stringtable_append(&self, str: &str) -> bool {
-        self.stringtable
-            .write()
-            .expect("mutex saftey")
-            .insert(str.to_lowercase())
-    }
-    #[must_use]
-    /// # Panics
-    pub fn stringtable_exists(&self, str: &str, is_config: bool) -> bool {
-        let target = if is_config {
-            (str[1..]).to_lowercase()
-        } else {
-            str.to_lowercase()
-        };
-        self.stringtable
-            .read()
-            .expect("mutex saftey")
-            .contains(&target)
     }
 }
 

--- a/libs/config/src/analyze/lints/c01_invalid_value.rs
+++ b/libs/config/src/analyze/lints/c01_invalid_value.rs
@@ -61,7 +61,6 @@ impl LintRunner<LintData> for RunnerValue {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Value,
@@ -91,7 +90,6 @@ impl LintRunner<LintData> for RunnerItem {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Item,

--- a/libs/config/src/analyze/lints/c02_duplicate_property.rs
+++ b/libs/config/src/analyze/lints/c02_duplicate_property.rs
@@ -65,7 +65,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Config,

--- a/libs/config/src/analyze/lints/c03_duplicate_classes.rs
+++ b/libs/config/src/analyze/lints/c03_duplicate_classes.rs
@@ -69,7 +69,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Config,

--- a/libs/config/src/analyze/lints/c04_external_missing.rs
+++ b/libs/config/src/analyze/lints/c04_external_missing.rs
@@ -64,7 +64,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Config,

--- a/libs/config/src/analyze/lints/c05_external_parent_case.rs
+++ b/libs/config/src/analyze/lints/c05_external_parent_case.rs
@@ -64,7 +64,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Class,

--- a/libs/config/src/analyze/lints/c06_unexpected_array.rs
+++ b/libs/config/src/analyze/lints/c06_unexpected_array.rs
@@ -61,7 +61,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &crate::Property,

--- a/libs/config/src/analyze/lints/c07_expected_array.rs
+++ b/libs/config/src/analyze/lints/c07_expected_array.rs
@@ -61,7 +61,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &crate::Property,

--- a/libs/config/src/analyze/lints/c08_missing_semicolon.rs
+++ b/libs/config/src/analyze/lints/c08_missing_semicolon.rs
@@ -76,7 +76,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &crate::Property,

--- a/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
+++ b/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
@@ -85,7 +85,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Config,

--- a/libs/config/src/analyze/lints/c10_class_missing_braces.rs
+++ b/libs/config/src/analyze/lints/c10_class_missing_braces.rs
@@ -66,7 +66,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &crate::Property,

--- a/libs/config/src/analyze/lints/c11_file_type.rs
+++ b/libs/config/src/analyze/lints/c11_file_type.rs
@@ -99,7 +99,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&Processed>,
         target: &crate::Property,

--- a/libs/config/tests/lints.rs
+++ b/libs/config/tests/lints.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
-use hemtt_common::config::{BuildInfo, ProjectConfig};
+use hemtt_common::config::ProjectConfig;
 use hemtt_preprocessor::Processor;
 use hemtt_workspace::{reporting::WorkspaceFiles, LayerType};
 
@@ -45,10 +45,10 @@ fn lint(file: &str) -> String {
     let source = workspace.join(format!("{file}.hpp")).unwrap();
     let processed = Processor::run(&source).unwrap();
     let test_config = ProjectConfig::test_project();
-    let build_info = BuildInfo::new(test_config.prefix());
-    let _ =
-        build_info.stringtable_append(&format!("{}validEntry", build_info.stringtable_prefix()));
-    let parsed = hemtt_config::parse(Some(&test_config), Some(&build_info), &processed);
+    // let build_info = BuildInfo::new(test_config.prefix());
+    // let _ =
+    // build_info.stringtable_append(&format!("{}validEntry", build_info.stringtable_prefix()));
+    let parsed = hemtt_config::parse(Some(&test_config), &processed);
     let workspacefiles = WorkspaceFiles::new();
     match parsed {
         Ok(config) => config

--- a/libs/config/tests/rapify.rs
+++ b/libs/config/tests/rapify.rs
@@ -41,7 +41,7 @@ fn rapify(dir: &str) {
         .unwrap();
     let source = workspace.join("source.hpp").unwrap();
     let processed = Processor::run(&source).unwrap();
-    let parsed = hemtt_config::parse(None, None, &processed);
+    let parsed = hemtt_config::parse(None, &processed);
     let workspacefiles = hemtt_workspace::reporting::WorkspaceFiles::new();
     if let Err(e) = &parsed {
         let e = e

--- a/libs/sqf/src/analyze/lints/s01_command_required_version.rs
+++ b/libs/sqf/src/analyze/lints/s01_command_required_version.rs
@@ -61,7 +61,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         _config: &hemtt_common::config::LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Statements,
@@ -70,8 +69,7 @@ impl LintRunner<LintData> for Runner {
         let Some(processed) = processed else {
             return Vec::new();
         };
-        let (addon, database) = data;
-        let Some(required) = addon.build_data().required_version() else {
+        let Some(required) = data.addon.build_data().required_version() else {
             // TODO what to do here?
             return Vec::new();
         };
@@ -81,14 +79,14 @@ impl LintRunner<LintData> for Runner {
             u8::try_from(required.0.minor()).unwrap_or_default(),
         );
         let required = (wiki_version, required.1, required.2);
-        let (command, usage, usage_span) = target.required_version(database);
+        let (command, usage, usage_span) = target.required_version(&data.database);
         if wiki_version < usage {
             errors.push(Arc::new(CodeS01CommandRequiredVersion::new(
                 command,
                 usage_span,
                 usage,
                 required,
-                *database.wiki().version(),
+                *data.database.wiki().version(),
                 processed,
             )));
         }

--- a/libs/sqf/src/analyze/lints/s02_event_handlers.rs
+++ b/libs/sqf/src/analyze/lints/s02_event_handlers.rs
@@ -164,7 +164,6 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: std::collections::HashMap<String, LintConfig>,
         processed: Option<&Processed>,
         target: &Statements,
@@ -174,7 +173,6 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
             return Vec::new();
         };
         let mut codes: Codes = Vec::new();
-        let (addon, database) = data;
         for statement in target.content() {
             for expression in statement.walk_expressions() {
                 let Some((ns, name, id, target)) = get_namespaces(expression) else {
@@ -187,7 +185,7 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
                     // Requires arma3-wiki to parse and provide https://community.bistudio.com/wiki/inputAction/actions
                     continue;
                 }
-                let eh = database.wiki().event_handler(&id.0);
+                let eh = data.database.wiki().event_handler(&id.0);
                 codes.extend(check_unknown(
                     &ns,
                     &name,
@@ -195,11 +193,11 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
                     target.map(|t| &**t),
                     &eh,
                     processed,
-                    database,
+                    &data.database,
                     config.get("event_unknown"),
                 ));
                 codes.extend(check_version(
-                    addon, &ns, &name, &id, &eh, processed, database,
+                    &data.addon, &ns, &name, &id, &eh, processed, &data.database,
                 ));
             }
         }

--- a/libs/sqf/src/analyze/lints/s03_static_typename.rs
+++ b/libs/sqf/src/analyze/lints/s03_static_typename.rs
@@ -58,7 +58,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s04_command_case.rs
+++ b/libs/sqf/src/analyze/lints/s04_command_case.rs
@@ -61,7 +61,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&Processed>,
         target: &Self::Target,
@@ -78,7 +77,7 @@ impl LintRunner<LintData> for Runner {
                 return Vec::new();
             }
         }
-        let Some(wiki) = data.1.wiki().commands().get(command) else {
+        let Some(wiki) = data.database.wiki().commands().get(command) else {
             return Vec::new();
         };
         if command != wiki.name() {

--- a/libs/sqf/src/analyze/lints/s05_if_assign.rs
+++ b/libs/sqf/src/analyze/lints/s05_if_assign.rs
@@ -62,7 +62,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s06_find_in_str.rs
+++ b/libs/sqf/src/analyze/lints/s06_find_in_str.rs
@@ -54,7 +54,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s07_select_parse_number.rs
+++ b/libs/sqf/src/analyze/lints/s07_select_parse_number.rs
@@ -63,7 +63,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&Processed>,
         target: &Self::Target,
@@ -72,7 +71,6 @@ impl LintRunner<LintData> for Runner {
         let Some(processed) = processed else {
             return Vec::new();
         };
-        let (_, database) = data;
         let Expression::BinaryCommand(BinaryCommand::Named(name), expression, condition, _) = target
         else {
             return Vec::new();
@@ -99,9 +97,9 @@ impl LintRunner<LintData> for Runner {
             | Expression::ConsumeableArray(_, _)
             | Expression::Variable(_, _) => false,
             Expression::String(_, _, _) | Expression::Boolean(_, _) => true,
-            Expression::NularCommand(cmd, _) => safe_command(cmd.as_str(), database),
-            Expression::UnaryCommand(cmd, _, _) => safe_command(cmd.as_str(), database),
-            Expression::BinaryCommand(cmd, _, _, _) => safe_command(cmd.as_str(), database),
+            Expression::NularCommand(cmd, _) => safe_command(cmd.as_str(), &data.database),
+            Expression::UnaryCommand(cmd, _, _) => safe_command(cmd.as_str(), &data.database),
+            Expression::BinaryCommand(cmd, _, _, _) => safe_command(cmd.as_str(), &data.database),
         }) {
             return Vec::new();
         }

--- a/libs/sqf/src/analyze/lints/s08_format_args.rs
+++ b/libs/sqf/src/analyze/lints/s08_format_args.rs
@@ -65,7 +65,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s09_banned_command.rs
+++ b/libs/sqf/src/analyze/lints/s09_banned_command.rs
@@ -68,7 +68,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&Processed>,
         target: &Self::Target,
@@ -85,7 +84,7 @@ impl LintRunner<LintData> for Runner {
                 return Vec::new();
             }
         }
-        let Some(wiki) = data.1.wiki().commands().get(command) else {
+        let Some(wiki) = data.database.wiki().commands().get(command) else {
             return Vec::new();
         };
         if wiki.groups().contains(&String::from("Broken Commands")) {

--- a/libs/sqf/src/analyze/lints/s11_if_not_else.rs
+++ b/libs/sqf/src/analyze/lints/s11_if_not_else.rs
@@ -54,7 +54,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
+++ b/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
@@ -62,7 +62,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s18_in_vehicle_check.rs
+++ b/libs/sqf/src/analyze/lints/s18_in_vehicle_check.rs
@@ -57,7 +57,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s19_extra_not.rs
+++ b/libs/sqf/src/analyze/lints/s19_extra_not.rs
@@ -53,7 +53,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s20_bool_static_comparison.rs
+++ b/libs/sqf/src/analyze/lints/s20_bool_static_comparison.rs
@@ -52,7 +52,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s21_invalid_comparisons.rs
+++ b/libs/sqf/src/analyze/lints/s21_invalid_comparisons.rs
@@ -57,7 +57,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s22_this_call.rs
+++ b/libs/sqf/src/analyze/lints/s22_this_call.rs
@@ -57,7 +57,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s23_reassign_reserved_variable.rs
+++ b/libs/sqf/src/analyze/lints/s23_reassign_reserved_variable.rs
@@ -66,7 +66,6 @@ impl LintRunner<LintData> for StatementsRunner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,
@@ -130,7 +129,6 @@ impl LintRunner<LintData> for ExpressionRunner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/src/analyze/lints/s24_marker_spam.rs
+++ b/libs/sqf/src/analyze/lints/s24_marker_spam.rs
@@ -64,7 +64,6 @@ impl LintRunner<LintData> for Runner {
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
         target: &Self::Target,

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use hemtt_common::config::{BuildInfo, ProjectConfig};
+use hemtt_common::config::ProjectConfig;
 use hemtt_preprocessor::Processor;
 use hemtt_sqf::{analyze::analyze, parser::database::Database};
 use hemtt_workspace::{addons::Addon, reporting::WorkspaceFiles, LayerType};
@@ -54,15 +54,14 @@ fn lint(file: &str) -> String {
 
     let config_path_full = std::path::PathBuf::from(ROOT).join("project_tests.toml");
     let config = ProjectConfig::from_file(&config_path_full).unwrap();
-    let build_info = BuildInfo::new(config.prefix()).with_release(true);
-    let _ = build_info.stringtable_append(&format!("str_{}_validEntry", config.prefix()));
+    // let build_info = BuildInfo::new(config.prefix()).with_release(true);
+    // let _ = build_info.stringtable_append(&format!("str_{}_validEntry", config.prefix()));
 
     match hemtt_sqf::parser::run(&database, &processed) {
         Ok(sqf) => {
-            let codes = analyze(
+            let (codes, _) = analyze(
                 &sqf,
                 Some(&config),
-                Some(&build_info),
                 &processed,
                 Arc::new(Addon::test_addon()),
                 database.clone(),

--- a/libs/stringtable/src/analyze/lints/l01_sorted.rs
+++ b/libs/stringtable/src/analyze/lints/l01_sorted.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use hemtt_common::config::LintConfig;
-use hemtt_workspace::{lint::{AnyLintRunner, Lint, LintRunner}, reporting::{Code, Codes, Diagnostic, Severity}, WorkspacePath};
+use hemtt_workspace::{lint::{AnyLintRunner, Lint, LintRunner}, reporting::{Code, Codes, Diagnostic, Severity}};
 
 use crate::{analyze::LintData, Project};
 
@@ -33,34 +33,31 @@ impl Lint<LintData> for LintL01Sorted {
     }
 }
 
-pub type StringtableData = (Project, WorkspacePath, String);
-
 pub struct Runner;
 impl LintRunner<LintData> for Runner {
-    type Target = Vec<StringtableData>;
+    type Target = Vec<Project>;
     fn run(
         &self,
         _project: Option<&hemtt_common::config::ProjectConfig>,
-        _build_info: Option<&hemtt_common::config::BuildInfo>,
         config: &hemtt_common::config::LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
-        target: &Vec<StringtableData>,
+        target: &Vec<Project>,
         _data: &LintData,
     ) -> Codes {
         let mut unsorted = Vec::new();
         let mut codes: Codes = Vec::new();
         let only_lang = matches!(config.option("only-lang"), Some(toml::Value::Boolean(true)));
-        for (project, path, existing) in target {
+        for project in target {
             let mut project = project.clone();
             if !only_lang {
                 project.sort();
             }
             let mut writer = String::new();
             if let Err(e) = project.to_writer(&mut writer) {
-                panic!("Failed to write stringtable for {path}: {e}");
+                panic!("Failed to write stringtable for {}: {e}", project.path());
             }
-            if writer.trim() != existing.trim() {
-                unsorted.push(path.as_str().to_string());
+            if writer.trim() != project.source().trim() {
+                unsorted.push(project.path().as_str().to_string());
             }
         }
         if unsorted.len() <= 3 {

--- a/libs/stringtable/src/analyze/lints/l02_usage.rs
+++ b/libs/stringtable/src/analyze/lints/l02_usage.rs
@@ -1,0 +1,131 @@
+use std::{collections::HashMap, sync::Arc};
+use std::io::Write;
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{lint::{AnyLintRunner, Lint, LintRunner}, reporting::{Code, Codes, Diagnostic, Severity}};
+
+use crate::{analyze::LintData, Project};
+
+crate::analyze::lint!(LintL02Usage);
+
+impl Lint<LintData> for LintL02Usage {
+    fn ident(&self) -> &'static str {
+        "usasge"
+    }
+
+    fn sort(&self) -> u32 {
+        20
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks if stringtables are sorted"
+    }
+
+    fn documentation(&self) -> &'static str {
+        "Stringtables should be sorted alphabetically and the keys in the order from the [Arma 3 Wiki](https://community.bistudio.com/wiki/Stringtable.xml#Supported_Languages)."
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::warning()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+pub struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Vec<Project>;
+    fn run(
+        &self,
+        project: Option<&hemtt_common::config::ProjectConfig>,
+        _config: &hemtt_common::config::LintConfig,
+        _processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Vec<Project>,
+        data: &LintData,
+    ) -> Codes {
+        let mut codes: Codes = Vec::new();
+        let mut all = HashMap::new();
+        for project in target {
+            for (key, positions) in &project.keys {
+                all.entry(key.to_lowercase()).or_insert_with(Vec::new).extend(positions.clone());
+            }
+        }
+        let mut unused = all.keys().cloned().collect::<Vec<_>>();
+        let mut usages = Vec::new();
+        for addon in &data.addons {
+            let usage = addon.build_data().localizations().lock().expect("lock").clone();
+            usages.extend(usage);
+        }
+        let prefix = format!("str_{}", project.map_or("", |p| p.prefix()));
+        println!("{} usages", usages.len());
+        for (key, position) in usages {
+            if all.iter().any(|(k, _)| k == &key) {
+                if let Some(pos) = unused.iter().position(|k| k == &key) {
+                    unused.remove(pos);
+                }
+            } else if key.starts_with(&prefix) {
+                println!("{key} not found - {position:?}");
+            }
+        }
+        if !unused.is_empty() {
+            unused.sort();
+            unused.dedup();
+            let mut file = std::fs::File::create(".hemttout/unused_stringtables.txt").expect("Failed to create file");
+            for key in &unused {
+                let pos = all.get(key).expect("unused must exist in all").first().expect("must have a position");
+                writeln!(file, "{} - {}:{}:{}", key, pos.path().as_str().trim_start_matches('/'), pos.start().1.0, pos.start().1.1).expect("Failed to write to file");
+            }
+            codes.push(Arc::new(CodeStringtableUnused::new(unused.len() as u64, Severity::Warning)));
+        }
+        codes
+    }
+}
+
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeStringtableUnused {
+    count: u64,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeStringtableUnused {
+    fn ident(&self) -> &'static str {
+        "L-L02U"
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        format!("There are {} unused keys in stringtables.", self.count)
+    }
+
+    fn note(&self) -> Option<String> {
+        Some(String::from("A list has been generated in .hemttout/unused_stringtables.txt"))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeStringtableUnused {
+    #[must_use]
+    pub fn new(count: u64, severity: Severity) -> Self {
+        Self {
+            count,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed()
+    }
+
+    fn generate_processed(mut self) -> Self {
+        self.diagnostic = Some(Diagnostic::from_code(&self));
+        self
+    }
+}

--- a/libs/stringtable/src/analyze/mod.rs
+++ b/libs/stringtable/src/analyze/mod.rs
@@ -1,6 +1,7 @@
-use hemtt_common::config::{BuildInfo, ProjectConfig};
-use hemtt_workspace::{lint::LintManager, lint_manager, reporting::Codes};
-use lints::l01_sorted::StringtableData;
+use hemtt_common::config::ProjectConfig;
+use hemtt_workspace::{addons::Addon, lint::LintManager, lint_manager, reporting::Codes};
+
+use crate::Project;
 
 pub mod lints {
     automod::dir!(pub "src/analyze/lints");
@@ -8,14 +9,16 @@ pub mod lints {
 
 lint_manager!(stringtable, vec![]);
 
-pub struct LintData {}
+pub struct LintData {
+    pub(crate) addons: Vec<Addon>,
+}
 
 pub fn lint_one(
-    addon: &StringtableData,
-    project: Option<&ProjectConfig>,
-    build_info: Option<&BuildInfo>,
+    project: &Project,
+    project_config: Option<&ProjectConfig>,
+    addons: Vec<Addon>,
 ) -> Codes {
-    let mut manager = LintManager::new(project.map_or_else(Default::default, |project| {
+    let mut manager = LintManager::new(project_config.map_or_else(Default::default, |project| {
         project.lints().stringtables().clone()
     }));
     if let Err(e) = manager.extend(
@@ -26,16 +29,16 @@ pub fn lint_one(
     ) {
         return e;
     }
-    manager.run(&LintData {}, project, build_info, None, addon)
+    manager.run(&LintData { addons }, project_config, None, project)
 }
 
 #[allow(clippy::ptr_arg)] // Needed for &Vec for &dyn Any
 pub fn lint_all(
-    addons: &Vec<StringtableData>,
-    project: Option<&ProjectConfig>,
-    build_info: Option<&BuildInfo>,
+    projects: &Vec<Project>,
+    project_config: Option<&ProjectConfig>,
+    addons: Vec<Addon>,
 ) -> Codes {
-    let mut manager = LintManager::new(project.map_or_else(Default::default, |project| {
+    let mut manager = LintManager::new(project_config.map_or_else(Default::default, |project| {
         project.lints().stringtables().clone()
     }));
     if let Err(e) = manager.extend(
@@ -46,5 +49,5 @@ pub fn lint_all(
     ) {
         return e;
     }
-    manager.run(&LintData {}, project, build_info, None, addons)
+    manager.run(&LintData { addons }, project_config, None, projects)
 }

--- a/libs/stringtable/src/rapify.rs
+++ b/libs/stringtable/src/rapify.rs
@@ -1,5 +1,4 @@
 use crate::{Key, Project, ALL_LANGUAGES};
-use hemtt_workspace::WorkspacePath;
 use tracing::{trace, warn};
 
 #[derive(Default, Debug)]
@@ -22,16 +21,16 @@ struct Translation {
 ///
 /// # Panics
 /// If the files can't be read or written from the vfs
-pub fn convert_stringtable(project: &Project, xml_path: &WorkspacePath) {
+pub fn convert_stringtable(project: &Project) {
     let result = rapify(project);
 
     if result.is_some() {
         // Create stringtable.bin
-        let xmlb_path = xml_path.with_extension("bin").expect("vfs error");
+        let xmlb_path = project.path().with_extension("bin").expect("vfs error");
         let mut xmlb_file = xmlb_path.create_file().expect("vfs error");
 
         // Remove Original stringtable.xml
-        xml_path.vfs().remove_file().expect("vfs error");
+        project.path().vfs().remove_file().expect("vfs error");
 
         // Write data to virtual file
         let data = result.expect("data struct valid");
@@ -48,7 +47,7 @@ pub fn convert_stringtable(project: &Project, xml_path: &WorkspacePath) {
             data.translations.len()
         );
     } else {
-        trace!("skpping binerization of stringtable{:?}", xml_path);
+        trace!("skpping binerization of stringtable{:?}", project.path());
     }
 }
 

--- a/libs/stringtable/tests/bin.rs
+++ b/libs/stringtable/tests/bin.rs
@@ -1,15 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
-use std::io::BufReader;
-
 use hemtt_stringtable::{rapify::rapify, Project};
+use hemtt_workspace::WorkspacePath;
 
 #[test]
 fn bin_pass() {
-    let stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/bin/pass.xml").unwrap(),
-    ))
-    .unwrap();
+    let stringtable =
+        Project::read(WorkspacePath::slim_file("tests/bin/pass.xml").unwrap()).unwrap();
     // Has 2 languages with unique translations
     let bin = rapify(&stringtable);
     assert!(bin.is_some());
@@ -18,10 +15,8 @@ fn bin_pass() {
 
 #[test]
 fn bin_containers() {
-    let stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/bin/containers.xml").unwrap(),
-    ))
-    .unwrap();
+    let stringtable =
+        Project::read(WorkspacePath::slim_file("tests/bin/containers.xml").unwrap()).unwrap();
     // Has 2 languages with unique translations
     let bin = rapify(&stringtable);
     assert!(bin.is_some());
@@ -30,10 +25,8 @@ fn bin_containers() {
 
 #[test]
 fn bin_invalid() {
-    let stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/bin/invalid.xml").unwrap(),
-    ))
-    .unwrap();
+    let stringtable =
+        Project::read(WorkspacePath::slim_file("tests/bin/invalid.xml").unwrap()).unwrap();
     // Cannot be binnerized
     let bin = rapify(&stringtable);
     assert!(bin.is_none());
@@ -41,10 +34,8 @@ fn bin_invalid() {
 
 #[test]
 fn bin_unescaped() {
-    let stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/bin/unescaped.xml").unwrap(),
-    ))
-    .unwrap();
+    let stringtable =
+        Project::read(WorkspacePath::slim_file("tests/bin/unescaped.xml").unwrap()).unwrap();
     // Cannot be binnerized
     let bin = rapify(&stringtable);
     assert!(bin.is_none());

--- a/libs/stringtable/tests/lints.rs
+++ b/libs/stringtable/tests/lints.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::unwrap_used)]
 
-use std::io::BufReader;
-
 use hemtt_stringtable::{
     analyze::{lint_all, lint_one},
     Project,
@@ -34,21 +32,11 @@ fn lint(file: &str) -> String {
         .unwrap();
     let source = workspace.join(format!("{file}.xml")).unwrap();
     let workspace_files = WorkspaceFiles::new();
-
-    let existing = source.read_to_string().expect("vfs issue");
-    let stringtable = Project::from_reader(BufReader::new(existing.as_bytes())).unwrap();
+    let stringtable = Project::read(source).unwrap();
 
     let mut codes: Codes = Vec::new();
-    codes.extend(lint_one(
-        &(stringtable.clone(), workspace.clone(), existing.clone()),
-        None,
-        None,
-    ));
-    codes.extend(lint_all(
-        &vec![(stringtable, workspace, existing)],
-        None,
-        None,
-    ));
+    codes.extend(lint_one(&stringtable, None, vec![]));
+    codes.extend(lint_all(&vec![stringtable], None, vec![]));
 
     codes
         .iter()

--- a/libs/stringtable/tests/sort.rs
+++ b/libs/stringtable/tests/sort.rs
@@ -1,17 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
-use std::io::BufReader;
-
 use hemtt_stringtable::Project;
+use hemtt_workspace::WorkspacePath;
 
 #[test]
 fn sort_ace_arsenal() {
-    let mut stringtable: Project = quick_xml::de::from_str(
-        std::fs::read_to_string("tests/ace_arsenal.xml")
-            .unwrap()
-            .as_str(),
-    )
-    .unwrap();
+    let mut stringtable =
+        Project::read(WorkspacePath::slim_file("tests/ace_arsenal.xml").unwrap()).unwrap();
     insta::assert_debug_snapshot!(stringtable);
 
     stringtable.sort();
@@ -21,10 +16,8 @@ fn sort_ace_arsenal() {
 
 #[test]
 fn sort_comments() {
-    let mut stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/sort/comments.xml").unwrap(),
-    ))
-    .unwrap();
+    let mut stringtable =
+        Project::read(WorkspacePath::slim_file("tests/sort/comments.xml").unwrap()).unwrap();
     insta::assert_debug_snapshot!(stringtable);
 
     stringtable.sort();
@@ -39,10 +32,8 @@ fn sort_comments() {
 
 #[test]
 fn sort_gh822() {
-    let mut stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/sort/gh822.xml").unwrap(),
-    ))
-    .unwrap();
+    let mut stringtable =
+        Project::read(WorkspacePath::slim_file("tests/sort/gh822.xml").unwrap()).unwrap();
     stringtable.sort();
 
     insta::assert_debug_snapshot!(stringtable);
@@ -55,10 +46,8 @@ fn sort_gh822() {
 
 #[test]
 fn sort_containers() {
-    let mut stringtable = Project::from_reader(BufReader::new(
-        std::fs::File::open("tests/sort/containers.xml").unwrap(),
-    ))
-    .unwrap();
+    let mut stringtable =
+        Project::read(WorkspacePath::slim_file("tests/sort/containers.xml").unwrap()).unwrap();
     stringtable.sort();
 
     insta::assert_debug_snapshot!(stringtable);

--- a/libs/stringtable/tests/totals.rs
+++ b/libs/stringtable/tests/totals.rs
@@ -1,15 +1,12 @@
 #![allow(clippy::unwrap_used)]
 
 use hemtt_stringtable::Project;
+use hemtt_workspace::WorkspacePath;
 
 #[test]
 fn totals_ace_arsenal() {
-    let stringtable: Project = quick_xml::de::from_str(
-        std::fs::read_to_string("tests/ace_arsenal.xml")
-            .unwrap()
-            .as_str(),
-    )
-    .unwrap();
+    let stringtable =
+        Project::read(WorkspacePath::slim_file("tests/ace_arsenal.xml").unwrap()).unwrap();
     insta::assert_debug_snapshot!(stringtable);
 
     assert_eq!(stringtable.name(), "ACE");

--- a/libs/workspace/src/addons.rs
+++ b/libs/workspace/src/addons.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::{fs::DirEntry, str::FromStr};
 
 use hemtt_common::config::AddonConfig;
@@ -9,6 +9,7 @@ use hemtt_common::prefix::{Prefix, FILES};
 use hemtt_common::version::Version;
 use tracing::{trace, warn};
 
+use crate::position::Position;
 use crate::WorkspacePath;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
@@ -238,6 +239,7 @@ type RequiredVersion = (Version, WorkspacePath, Range<usize>);
 #[derive(Debug, Clone, Default)]
 pub struct BuildData {
     required_version: Arc<RwLock<Option<RequiredVersion>>>,
+    localizations: Arc<Mutex<Vec<(String, Position)>>>,
 }
 
 impl BuildData {
@@ -245,6 +247,7 @@ impl BuildData {
     pub fn new() -> Self {
         Self {
             required_version: Arc::new(RwLock::new(None)),
+            localizations: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -272,6 +275,12 @@ impl BuildData {
             .required_version
             .write()
             .expect("the required version lock is poisoned") = Some((version, file, line));
+    }
+
+    #[must_use]
+    /// Fetches the localizations
+    pub fn localizations(&self) -> Arc<Mutex<Vec<(String, Position)>>> {
+        self.localizations.clone()
     }
 }
 

--- a/libs/workspace/src/path.rs
+++ b/libs/workspace/src/path.rs
@@ -23,6 +23,45 @@ pub struct WorkspacePath {
 }
 
 impl WorkspacePath {
+    /// Create a quick workspace with only the source layer
+    ///
+    /// Useful for tests and utilities
+    ///
+    /// # Errors
+    /// [`Error::Vfs`] if the workspace could not be created
+    pub fn slim(dir: &PathBuf) -> Result<Self, Error> {
+        super::Workspace::builder()
+            .physical(dir, LayerType::Source)
+            .finish(None, false, &hemtt_common::config::PDriveOption::Disallow)
+    }
+
+    /// Create a quick workspace with only the source layer
+    ///
+    /// Useful for tests and utilities
+    ///
+    /// # Errors
+    /// [`Error::Vfs`] if the workspace could not be created
+    ///
+    /// # Panics
+    /// If the path does not have a parent
+    pub fn slim_file<P: AsRef<Path>>(dir: P) -> Result<Self, Error> {
+        let dir = dir.as_ref();
+        super::Workspace::builder()
+            .physical(
+                &dir.parent()
+                    .expect("slim_file must have a parent")
+                    .to_path_buf(),
+                LayerType::Source,
+            )
+            .finish(None, false, &hemtt_common::config::PDriveOption::Disallow)?
+            .join(
+                dir.file_name()
+                    .expect("slim_file must have a file name")
+                    .to_str()
+                    .expect("utf-8"),
+            )
+    }
+
     #[must_use]
     /// Returns the underlying [`VfsPath`]
     pub fn vfs(&self) -> &VfsPath {


### PR DESCRIPTION
Changes the implementation of #876 

1. The Config and SQF modules always run before the Stringtables module
2. Config and SQF modules store their stringtable usage in `addon.build_data()`
3. A stringtable lint `L02` goes through the usage and stringtables, finding missing, unused, duplicates, etc.

This prevents the need for the buildinfo to be passed around everywhere, using instead the existing LintData that is passed to all lints. This will also provide stringtable usage data in a clean to the ls / possible future utils, which could be useful

- Also changes the lint that used `is_release` to have `always` and `release` options instead

- Needs something for `is_pedantic` still, not sure how I best want to handle this yet, but want to get these changes up 