### PR TITLE
Config - c11 ignore a3

### DIFF
--- a/libs/config/src/analyze/lints/c11_file_type.rs
+++ b/libs/config/src/analyze/lints/c11_file_type.rs
@@ -144,7 +144,7 @@ fn check(name: &str, value: &Str, allow_no_extension: bool, processed: &Processe
         return None;
     }
     let value_str = value_str.to_lowercase();
-    if value_str.starts_with("a3") {
+    if value_str.starts_with("\\a3") {
         return None;
     }
     if name == "sound" && value_str.starts_with("db") {

--- a/libs/config/src/analyze/lints/c11_file_type.rs
+++ b/libs/config/src/analyze/lints/c11_file_type.rs
@@ -116,11 +116,12 @@ impl LintRunner<LintData> for Runner {
         } else {
             false
         };
+        let name = name.as_str().to_lowercase();
         // Arrays
         if let Value::Array(values) = value {
             for value in &values.items {
                 if let Item::Str(value) = value {
-                    if let Some(code) = check(name.as_str(), value, allow_no_extension, processed, config) {
+                    if let Some(code) = check(&name, value, allow_no_extension, processed, config) {
                         codes.push(code);
                     }
                 }
@@ -129,7 +130,7 @@ impl LintRunner<LintData> for Runner {
         let Value::Str(value) = value else {
             return codes;
         };
-        if let Some(code) = check(name.as_str(), value, allow_no_extension, processed, config) {
+        if let Some(code) = check(&name, value, allow_no_extension, processed, config) {
             codes.push(code);
         }
         codes
@@ -140,6 +141,10 @@ fn check(name: &str, value: &Str, allow_no_extension: bool, processed: &Processe
     let value_str = value.value();
     // Skip if it contains no backslashes, probably a class name
     if !value_str.contains('\\') {
+        return None;
+    }
+    let value_str = value_str.to_lowercase();
+    if value_str.starts_with("a3") {
         return None;
     }
     if name == "sound" && value_str.starts_with("db") {
@@ -171,7 +176,6 @@ fn check(name: &str, value: &Str, allow_no_extension: bool, processed: &Processe
 }
 
 fn allowed_ext(name: &str) -> Vec<&str> {
-    let name = name.to_lowercase();
     if name.starts_with("animation") {
         if name.starts_with("animationsource") || name == "animationlist" {
             return vec![];
@@ -190,7 +194,7 @@ fn allowed_ext(name: &str) -> Vec<&str> {
     if name.starts_with("scud") {
         return vec!["rtm"];
     }
-    match name.as_str() {
+    match name {
         "model" | "uimodel" | "modelspecial" | "modeloptics" | "modelmagazine" | "cartridge" => vec!["p3d"],
         "editorpreview" => vec!["jpg", "jpeg", "paa", "pac"],
         "uipicture" | "icon" | "picture" | "wounds" => vec!["paa", "pac"],


### PR DESCRIPTION
Always allow no extension when the path starts with \a3, as it is probably just copy pasted