### PR TITLE
sqf: disable _this call lint

### DIFF
--- a/libs/sqf/src/analyze/lints/s22_this_call.rs
+++ b/libs/sqf/src/analyze/lints/s22_this_call.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, sync::Arc};
 
-use hemtt_common::config::LintConfig;
+use hemtt_common::config::{LintConfig, LintEnabled};
 use hemtt_workspace::{
     lint::{AnyLintRunner, Lint, LintRunner},
     reporting::{Code, Codes, Diagnostic, Processed, Severity},
@@ -42,7 +42,7 @@ When using `call`, the called code will inherit `_this` from the calling scope. 
     }
 
     fn default_config(&self) -> LintConfig {
-        LintConfig::warning()
+        LintConfig::warning().with_enabled(LintEnabled::Disabled)
     }
 
     fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {


### PR DESCRIPTION
The performance difference is minimal, and people seem to prefer with `_this`

Perhaps this can be done in the optimizer instead?