### PR TITLE
preprocessor: lazily clean output

### DIFF
--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -115,10 +115,12 @@ pub fn execute(cli: &Cli) -> Result<(), Error> {
 
     if let Some(threads) = cli.global.threads {
         debug!("Using custom thread count: {threads}");
-        if let Err(e) = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build_global()
-        {
+        let mut builder = rayon::ThreadPoolBuilder::new().num_threads(threads);
+        if threads == 1 {
+            // helps with profiling to just use the main thread
+            builder = builder.use_current_thread();
+        }
+        if let Err(e) = builder.build_global() {
             error!("Failed to initialize thread pool: {e}");
         }
     }

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -248,7 +248,6 @@ pub fn clean_output(processed: &Processed) {
         clean_cursor += chars;
         comitted_line += 1;
     }
-    // processed.clean_output = output;
     processed
         .clean_output
         .write()


### PR DESCRIPTION
Cleaning the processed output of configs could take a long time

This is mostly due to the mappings function, which currently iterates over all mappings to find the correct one, this function could definitely use a rewrite.

The temporary solution, is just to lazily create the cleaned output the first time a function that reads from it is called. This "fixed" the performance regression, but the VSCode extension will still suffer from the root issue on very large configs