### PR TITLE
preprocessor: mapping iter

### DIFF
--- a/libs/sqf/src/analyze/lints/s04_command_case.rs
+++ b/libs/sqf/src/analyze/lints/s04_command_case.rs
@@ -142,7 +142,7 @@ impl CodeS04CommandCase {
     #[must_use]
     pub fn new(span: Range<usize>, used: String, wiki: String, processed: &Processed, severity: Severity) -> Self {
         Self {
-            include: processed.mappings(span.end).first().is_some_and(|mapping| {
+            include: processed.mappings(span.end).next().is_some_and(|mapping| {
                 mapping.original().path().is_include()
             }),
             severity,

--- a/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
+++ b/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
@@ -165,11 +165,9 @@ impl CodeS17VarAllCaps {
             return self;
         };
         self.diagnostic = Some(diagnostic.clone());
-        let mut mappings = processed.mappings(self.span.start);
-        mappings.pop();
+        let mut mappings = processed.mappings(self.span.start).skip(1);
         let symbol = Symbol::Word(self.ident.clone());
         let Some(mapping) = mappings
-            .iter()
             .find(|m| {
                 m.token().symbol() == &symbol
             }) else {

--- a/libs/sqf/src/analyze/lints/s28_banned_macros.rs
+++ b/libs/sqf/src/analyze/lints/s28_banned_macros.rs
@@ -87,7 +87,7 @@ impl LintRunner<LintData> for Runner {
                         let span = target.span();
                         if processed
                             .mappings(span.start)
-                            .first()
+                            .next()
                             .is_some_and(|m| m.original().path().is_include())
                         {
                             continue;

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -323,15 +323,15 @@ impl Processed {
             .collect()
     }
 
-    #[must_use]
+    // #[must_use]
     /// Get the tree mapping at a position in the stringified output
-    pub fn mappings(&self, offset: usize) -> Vec<&Mapping> {
+    pub fn mappings(&self, offset: usize) -> impl Iterator<Item = &Mapping> {
         self.mappings
             .iter()
-            .filter(|map| {
+            .filter(move |map| {
                 map.processed_start().offset() <= offset && map.processed_end().offset() > offset
             })
-            .collect()
+            // .collect()
     }
 
     #[must_use]
@@ -343,16 +343,19 @@ impl Processed {
     #[must_use]
     /// Get the deepest tree mapping at a position in the stringified output
     pub fn mapping(&self, offset: usize) -> Option<&Mapping> {
-        self.mappings(offset).last().copied()
+        self.mappings(offset).last()
     }
 
     #[must_use]
     /// Get the deepest tree mapping at a position in the stringified output
     pub fn mapping_no_macros(&self, offset: usize) -> Option<&Mapping> {
+        // self.mappings(offset)
+        //     .into_iter()
+        //     .rev()
+        //     .find(|m| !m.was_macro)
         self.mappings(offset)
-            .into_iter()
-            .rev()
-            .find(|m| !m.was_macro)
+            .filter(|m| !m.was_macro)
+            .last()
     }
 
     #[must_use]

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -325,11 +325,9 @@ impl Processed {
 
     /// Get the tree mapping at a position in the stringified output
     pub fn mappings(&self, offset: usize) -> impl Iterator<Item = &Mapping> {
-        self.mappings
-            .iter()
-            .filter(move |map| {
-                map.processed_start().offset() <= offset && map.processed_end().offset() > offset
-            })
+        self.mappings.iter().filter(move |map| {
+            map.processed_start().offset() <= offset && map.processed_end().offset() > offset
+        })
     }
 
     #[must_use]
@@ -347,9 +345,7 @@ impl Processed {
     #[must_use]
     /// Get the deepest tree mapping at a position in the stringified output
     pub fn mapping_no_macros(&self, offset: usize) -> Option<&Mapping> {
-        self.mappings(offset)
-            .filter(|m| !m.was_macro)
-            .last()
+        self.mappings(offset).filter(|m| !m.was_macro).last()
     }
 
     #[must_use]

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -323,7 +323,6 @@ impl Processed {
             .collect()
     }
 
-    // #[must_use]
     /// Get the tree mapping at a position in the stringified output
     pub fn mappings(&self, offset: usize) -> impl Iterator<Item = &Mapping> {
         self.mappings
@@ -331,7 +330,6 @@ impl Processed {
             .filter(move |map| {
                 map.processed_start().offset() <= offset && map.processed_end().offset() > offset
             })
-            // .collect()
     }
 
     #[must_use]

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -347,10 +347,6 @@ impl Processed {
     #[must_use]
     /// Get the deepest tree mapping at a position in the stringified output
     pub fn mapping_no_macros(&self, offset: usize) -> Option<&Mapping> {
-        // self.mappings(offset)
-        //     .into_iter()
-        //     .rev()
-        //     .find(|m| !m.was_macro)
         self.mappings(offset)
             .filter(|m| !m.was_macro)
             .last()


### PR DESCRIPTION
Uses an iterator instead of collecting the mappings into a vec, needs to filter less mappings and avoids allocating vecs

`hemtt dev --just miscFixes -t 1` on POTATO went from 46 to 28 on my machine. This is a good change, but still far from a solution