### PR TITLE
preprocessor: cache line mappings for clean output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,5 @@ zip = "2.2.2"
 [profile.bench]
 lto = true
 
-[profile.release]
-debug = true
+# [profile.release]
+# debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,5 @@ zip = "2.2.2"
 [profile.bench]
 lto = true
 
-# [profile.release]
-# debug = true
+[profile.release]
+debug = true

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -115,11 +115,12 @@ pub fn execute(cli: &Cli) -> Result<(), Error> {
 
     if let Some(threads) = cli.global.threads {
         debug!("Using custom thread count: {threads}");
-        if let Err(e) = rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .use_current_thread()
-            .build_global()
-        {
+        let mut builder = rayon::ThreadPoolBuilder::new().num_threads(threads);
+        if threads == 1 {
+            // helps with profiling to just use the main thread
+            builder = builder.use_current_thread();
+        }
+        if let Err(e) = builder.build_global() {
             error!("Failed to initialize thread pool: {e}");
         }
     }

--- a/bin/src/lib.rs
+++ b/bin/src/lib.rs
@@ -117,6 +117,7 @@ pub fn execute(cli: &Cli) -> Result<(), Error> {
         debug!("Using custom thread count: {threads}");
         if let Err(e) = rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
+            .use_current_thread()
             .build_global()
         {
             error!("Failed to initialize thread pool: {e}");

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -24,6 +24,7 @@ pub struct Processed {
 
     /// string offset(start, stop), source, source position
     mappings: Vec<Mapping>,
+    mappings_newlines: Vec<(usize, usize)>,
 
     macros: HashMap<String, Vec<(Position, Definition)>>,
 
@@ -123,6 +124,9 @@ fn append_token(
         if str == "##" && string_stack.is_empty() {
             return Ok(());
         }
+        processed
+            .mappings_newlines
+            .push((processed.total, processed.mappings.len()));
         processed.mappings.push(Mapping {
             processed: (LineCol(processed.total, (processed.line, processed.col)), {
                 let chars = str.chars().count();
@@ -208,9 +212,16 @@ pub fn clean_output(processed: &mut Processed) {
             continue;
         }
 
-        let Some(map) = processed.mapping(cursor_offset + 1) else {
+        let Some(map) = processed
+            .mappings_newlines
+            .binary_search_by(|(offset, _)| offset.cmp(&(cursor_offset + 1)))
+            .ok()
+            .map(|index| &processed.raw_mappings()[processed.mappings_newlines[index].1])
+            .or_else(|| processed.mapping(cursor_offset + 1))
+        else {
             panic!("mapping not found for offset {cursor_offset}");
         };
+
         let pending_line = comitted_line + pending_empty;
         let linenum = map.original().start().line();
         let file = map
@@ -343,7 +354,10 @@ impl Processed {
     #[must_use]
     /// Get the deepest tree mapping at a position in the stringified output
     pub fn mapping(&self, offset: usize) -> Option<&Mapping> {
-        self.mappings(offset).last().copied()
+        // self.mappings(offset).last().copied()
+        self.mappings.iter().rev().find(|map| {
+            map.processed_start().offset() <= offset && map.processed_end().offset() > offset
+        })
     }
 
     #[must_use]

--- a/libs/workspace/src/reporting/processed.rs
+++ b/libs/workspace/src/reporting/processed.rs
@@ -354,7 +354,6 @@ impl Processed {
     #[must_use]
     /// Get the deepest tree mapping at a position in the stringified output
     pub fn mapping(&self, offset: usize) -> Option<&Mapping> {
-        // self.mappings(offset).last().copied()
         self.mappings.iter().rev().find(|map| {
             map.processed_start().offset() <= offset && map.processed_end().offset() > offset
         })


### PR DESCRIPTION
Fixes the performance regression from #892 

mapping() is still a really expensive function, but it's once again only used for generating error messages, and it's good enough for that