### PR TITLE
stringtables: less allocation, threads

### DIFF
--- a/bin/src/modules/stringtables.rs
+++ b/bin/src/modules/stringtables.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU16, Ordering},
+};
 
 use hemtt_stringtable::{
     Project,
@@ -9,8 +12,9 @@ use hemtt_workspace::{
     WorkspacePath,
     reporting::{Code, Diagnostic, Severity},
 };
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
-use crate::{Error, context::Context, report::Report};
+use crate::{Error, context::Context, progress::progress_bar, report::Report};
 
 use super::Module;
 
@@ -39,55 +43,71 @@ impl Module for Stringtables {
     }
 
     fn pre_build(&self, ctx: &Context) -> Result<Report, Error> {
-        let mut report = Report::new();
-
-        let mut stringtables = Vec::new();
+        let report = Arc::new(Mutex::new(Report::new()));
+        let mut paths = Vec::new();
         for root in ["addons", "optionals"] {
             if !ctx.workspace_path().join(root)?.exists()? {
                 continue;
             }
-            let paths = ctx
-                .workspace_path()
-                .join(root)
-                .expect("vfs issue")
-                .walk_dir()
-                .expect("vfs issue")
-                .into_iter()
-                .filter(|p| {
-                    let lower = p.filename().to_lowercase();
-                    if lower == "stringtable.csv" || lower == "stringtable.bin" {
-                        warn!("Stringtable [{}] will not be linted", p.as_str());
-                    }
-                    lower == "stringtable.xml"
-                })
-                .collect::<Vec<_>>();
-            for path in paths {
-                if path.exists().expect("vfs issue") {
-                    match Project::read(path.clone()) {
-                        Ok(project) => stringtables.push(project),
-                        Err(e) => {
-                            debug!("Failed to parse stringtable for {}: {}", path, e);
-                            report.push(Arc::new(CodeStringtableInvalid::new(path, e.to_string())));
+            paths.extend(
+                ctx.workspace_path()
+                    .join(root)
+                    .expect("vfs issue")
+                    .walk_dir()
+                    .expect("vfs issue")
+                    .into_iter()
+                    .filter(|p| {
+                        let lower = p.filename().to_lowercase();
+                        if lower == "stringtable.csv" || lower == "stringtable.bin" {
+                            warn!("Stringtable [{}] will not be linted", p.as_str());
                         }
-                    }
-                }
-            }
+                        lower == "stringtable.xml"
+                    }),
+            );
         }
+        let counter = AtomicU16::new(0);
+        let progress = progress_bar(paths.len() as u64).with_message("Processing Stringtables");
+        let results = paths
+            .into_par_iter()
+            .map(|path| match Project::read(path.clone()) {
+                Ok(project) => {
+                    let codes = lint_one(&project, Some(ctx.config()), ctx.addons().to_vec());
+                    if !codes.iter().any(|c| c.severity() == Severity::Error) {
+                        convert_stringtable(&project);
+                    }
+                    counter.fetch_add(1, Ordering::Relaxed);
+                    progress.inc(1);
+                    Some((project, codes))
+                }
+                Err(e) => {
+                    debug!("Failed to parse stringtable for {}: {}", path, e);
+                    report
+                        .lock()
+                        .expect("can lock")
+                        .push(Arc::new(CodeStringtableInvalid::new(path, e.to_string())));
+                    None
+                }
+            })
+            .filter_map(|x| x)
+            .collect::<Vec<_>>();
 
+        let mut report = Arc::into_inner(report)
+            .expect("last reference")
+            .into_inner()
+            .expect("can lock");
+        let mut stringtables = Vec::new();
+        for (project, codes) in results {
+            report.extend(codes);
+            stringtables.push(project);
+        }
+        progress.set_message("Linting Stringtables");
         report.extend(lint_all(
             &stringtables,
             Some(ctx.config()),
             ctx.addons().to_vec(),
         ));
-
-        for stringtable in stringtables {
-            let codes = lint_one(&stringtable, Some(ctx.config()), ctx.addons().to_vec());
-            if !codes.iter().any(|c| c.severity() == Severity::Error) {
-                convert_stringtable(&stringtable);
-            }
-            report.extend(codes);
-        }
-
+        progress.finish_and_clear();
+        info!("Checked {} stringtables", counter.load(Ordering::Relaxed));
         Ok(report)
     }
 }

--- a/libs/stringtable/src/lib.rs
+++ b/libs/stringtable/src/lib.rs
@@ -214,21 +214,21 @@ fn process_keys(
     path: &WorkspacePath,
 ) -> IndexMap<String, Vec<Position>> {
     let mut keys = IndexMap::new();
-    let mut all_keys: Vec<String> = Vec::with_capacity(20);
+    let mut all_keys: Vec<(&str, String)> = Vec::with_capacity(20);
     for package in &inner.packages {
         for package_inner in package.containers() {
             for key in package_inner.keys() {
-                all_keys.push(key.id().to_string());
+                all_keys.push((key.id(), format!("\"{}\"", key.id())));
             }
         }
         for key in package.keys() {
-            all_keys.push(key.id().to_string());
+            all_keys.push((key.id(), format!("\"{}\"", key.id())));
         }
     }
     let mut offset = 0;
     for (linenum, line) in source.lines().enumerate() {
-        for key in &all_keys {
-            if let Some(pos) = line.find(&format!("\"{key}\"")) {
+        for (key, needle) in &all_keys {
+            if let Some(pos) = line.find(needle.as_str()) {
                 keys.entry(key.to_lowercase())
                     .or_insert_with(Vec::new)
                     .push(Position::new(
@@ -243,7 +243,7 @@ fn process_keys(
         }
         offset += line.chars().count() + 1;
     }
-    for key in all_keys {
+    for (key, _) in all_keys {
         keys.entry(key.to_lowercase()).or_insert_with(Vec::new);
     }
     keys


### PR DESCRIPTION
- Adds a progress bar and `INFO Checked {} stringtables` messages
- Improvements to finding stringtable key positions, less allocations
- Processes the stringtables in a parallel iterator

Shaves another 800ms off on my machine