### PR TITLE
config: Add lint C12 for quoted math that could be run at build-time

### DIFF
--- a/bin/src/modules/rapifier.rs
+++ b/bin/src/modules/rapifier.rs
@@ -148,6 +148,9 @@ pub fn rapify(addon: &Addon, path: &WorkspacePath, ctx: &Context) -> Result<Repo
                 .iter()
                 .map(|(s, p)| (s.to_owned(), p.clone())),
         );
+    configreport.hints_and_notes().into_iter().for_each(|e| {
+        report.push(e.clone());
+    });
     configreport.warnings().into_iter().for_each(|e| {
         report.push(e.clone());
     });

--- a/bin/src/modules/rapifier.rs
+++ b/bin/src/modules/rapifier.rs
@@ -148,7 +148,7 @@ pub fn rapify(addon: &Addon, path: &WorkspacePath, ctx: &Context) -> Result<Repo
                 .iter()
                 .map(|(s, p)| (s.to_owned(), p.clone())),
         );
-    configreport.hints_and_notes().into_iter().for_each(|e| {
+    configreport.notes_and_helps().into_iter().for_each(|e| {
         report.push(e.clone());
     });
     configreport.warnings().into_iter().for_each(|e| {

--- a/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
+++ b/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
@@ -1,0 +1,174 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::{LintConfig, LintEnabled, ProjectConfig};
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Diagnostic, Processed, Severity},
+};
+
+use crate::{analyze::LintData, Item, Number, Value};
+
+crate::analyze::lint!(LintC12MathCouldBeUnquoted);
+
+impl Lint<LintData> for LintC12MathCouldBeUnquoted {
+    fn ident(&self) -> &'static str {
+        "math_could_be_unquoted"
+    }
+
+    fn sort(&self) -> u32 {
+        120
+    }
+
+    fn description(&self) -> &'static str {
+        "Reports on quoted math statements that could be evaulated at build-time"
+    }
+
+    fn documentation(&self) -> &'static str {
+        "### Example
+
+**Incorrect**
+```hpp
+x = '1+1';
+```
+
+**Correct**
+```hpp
+x = 1+1; // hemtt will evaluate at build-time to 2
+```
+
+### Explanation
+Quoted math statements will have to be evaulated in-game
+"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        // false-positives are possible
+        LintConfig::help().with_enabled(LintEnabled::Pedantic)
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Value;
+    fn run(
+        &self,
+        _project: Option<&ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&Processed>,
+        target: &crate::Value,
+        _data: &LintData,
+    ) -> Vec<std::sync::Arc<dyn Code>> {
+        let mut codes = Vec::new();
+        let Some(processed) = processed else {
+            return vec![];
+        };
+        match target {
+            Value::Array(arr) => {
+                for item in &arr.items {
+                    let Item::Str(str) = item else { continue };
+                    if let Some(code) = check(str, processed, config) {
+                        codes.push(code);
+                    }
+                }
+            }
+            Value::Str(str) => {
+                if let Some(code) = check(str, processed, config) {
+                    codes.push(code);
+                }
+            }
+            _ => {}
+        }
+
+        codes
+    }
+}
+
+fn check(
+    target_str: &crate::Str,
+    processed: &Processed,
+    config: &LintConfig,
+) -> Option<Arc<dyn Code>> {
+    let raw_string = target_str.value();
+    // check if it contains some kind of math ops (avoid false positives from `displayName = "556";`)
+    if !(raw_string.contains('+')
+        || raw_string.contains('-')
+        || raw_string.contains('*')
+        || raw_string.contains('/'))
+    {
+        return None;
+    }
+    // attempt to parse it as a number
+    let num = Number::try_evaulation(raw_string, target_str.span())?;
+    let span = target_str.span().start + 1..target_str.span().end - 1;
+    Some(Arc::new(Code12MathCouldBeUnquoted::new(
+        span,
+        processed,
+        format!("reducible to: {num}"),
+        config.severity(),
+    )))
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct Code12MathCouldBeUnquoted {
+    span: Range<usize>,
+    label: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for Code12MathCouldBeUnquoted {
+    fn ident(&self) -> &'static str {
+        "L-C12"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/analysis/config.html#math_could_be_unquoted")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        "Math could be unquoted".to_string()
+    }
+
+    fn label_message(&self) -> String {
+        self.label.clone()
+    }
+
+    fn note(&self) -> Option<String> {
+        Some("Could remove quotes to allow evaluation at build-time".to_string())
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl Code12MathCouldBeUnquoted {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        processed: &Processed,
+        label: String,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            label,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
+++ b/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
@@ -1,6 +1,6 @@
 use std::{ops::Range, sync::Arc};
 
-use hemtt_common::config::{LintConfig, LintEnabled, ProjectConfig};
+use hemtt_common::config::{LintConfig, ProjectConfig};
 use hemtt_workspace::{
     lint::{AnyLintRunner, Lint, LintRunner},
     reporting::{Code, Diagnostic, Processed, Severity},
@@ -33,17 +33,18 @@ x = '1+1';
 
 **Correct**
 ```hpp
-x = 1+1; // hemtt will evaluate at build-time to 2
+x = 1+1; // HEMTT will evaluate at build-time to 2
 ```
 
 ### Explanation
-Quoted math statements will have to be evaulated in-game
-"
+Quoted math statements will have to be evaulated on each use in-game, by allowing HEMTT to evaluate the math at build-time you can save some performance."
     }
 
     fn default_config(&self) -> LintConfig {
-        // false-positives are possible
-        LintConfig::help().with_enabled(LintEnabled::Pedantic)
+        // false-positives are possible - pabst
+        // I think this will be rare enough that people can ignore the help,
+        // imo the value in this being on by default is worth the false positives - brett
+        LintConfig::help()
     }
 
     fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -109,7 +109,7 @@ impl ConfigReport {
 
     #[must_use]
     /// Get the hints and notes
-    pub fn hints_and_notes(&self) -> Vec<&Arc<dyn Code>> {
+    pub fn notes_and_helps(&self) -> Vec<&Arc<dyn Code>> {
         self.codes
             .iter()
             .filter(|c| c.severity() == Severity::Help || c.severity() == Severity::Note)

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -108,6 +108,15 @@ impl ConfigReport {
     }
 
     #[must_use]
+    /// Get the hints and notes
+    pub fn hints_and_notes(&self) -> Vec<&Arc<dyn Code>> {
+        self.codes
+            .iter()
+            .filter(|c| c.severity() == Severity::Help || c.severity() == Severity::Note)
+            .collect::<Vec<_>>()
+    }
+
+    #[must_use]
     /// Get the warnings
     pub fn warnings(&self) -> Vec<&Arc<dyn Code>> {
         self.codes

--- a/libs/config/src/model/mod.rs
+++ b/libs/config/src/model/mod.rs
@@ -3,7 +3,7 @@ mod class;
 mod config;
 mod expression;
 mod ident;
-mod number;
+pub mod number;
 mod property;
 mod str;
 mod value;

--- a/libs/config/tests/lints.rs
+++ b/libs/config/tests/lints.rs
@@ -30,6 +30,8 @@ lint!(c08_missing_semicolon);
 lint!(c09_magwell_missing_magazine);
 lint!(c10_class_missing_braces);
 lint!(c11_file_type);
+lint!(c12_math_could_be_unquoted);
+lint!(c13_config_this_call);
 
 fn lint(file: &str) -> String {
     let folder = std::path::PathBuf::from(ROOT);
@@ -43,7 +45,8 @@ fn lint(file: &str) -> String {
         .unwrap();
     let source = workspace.join(format!("{file}.hpp")).unwrap();
     let processed = Processor::run(&source).unwrap();
-    let test_config = ProjectConfig::test_project();
+    let config_path_full = std::path::PathBuf::from(ROOT).join("project_tests.toml");
+    let test_config = ProjectConfig::from_file(&config_path_full).unwrap();
     let parsed = hemtt_config::parse(Some(&test_config), &processed);
     let workspacefiles = WorkspaceFiles::new();
     match parsed {

--- a/libs/config/tests/lints/c12_math_could_be_unquoted.hpp
+++ b/libs/config/tests/lints/c12_math_could_be_unquoted.hpp
@@ -1,0 +1,7 @@
+class test {
+    displayName = "12.7"; // ignore
+    irDotSize = "0.1/4"; // reducible
+    width = "0.5 * safeZoneW"; // ignore
+    sizes[] = { 0, "1", "(8-7)/3"}; // 0 and "1" ignored, 3rd is reducible
+    opticsZoomInit = "1 call (uiNamespace getVariable 'cba_optics_fnc_setOpticMagnificationHelper')"; // ignore
+};

--- a/libs/config/tests/lints/project_tests.toml
+++ b/libs/config/tests/lints/project_tests.toml
@@ -1,0 +1,11 @@
+# Same name/prefix as ProjectConfig::test_project();
+# With additional pedantic lints enabled
+
+name = "Advanced Banana Environment"
+prefix = "abe"
+
+[lints.config.math_could_be_unquoted]
+enabled = true
+
+[lints.config.config_this_call]
+enabled = true

--- a/libs/config/tests/snapshots/lints__config_error_c12_math_could_be_unquoted.snap
+++ b/libs/config/tests/snapshots/lints__config_error_c12_math_could_be_unquoted.snap
@@ -1,0 +1,20 @@
+---
+source: libs/config/tests/lints.rs
+expression: lint(stringify! (c12_math_could_be_unquoted))
+---
+[0m[1m[38;5;14mhelp[L-C12][0m[1m: Math could be unquoted[0m
+  [0m[36m┌─[0m c12_math_could_be_unquoted.hpp:3:18
+  [0m[36m│[0m
+[0m[36m3[0m [0m[36m│[0m     irDotSize = "[0m[36m0.1/4[0m"; // reducible
+  [0m[36m│[0m                  [0m[36m^^^^^[0m [0m[36mreducible to: 0.025[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: Could remove quotes to allow evaluation at build-time
+
+
+[0m[1m[38;5;14mhelp[L-C12][0m[1m: Math could be unquoted[0m
+  [0m[36m┌─[0m c12_math_could_be_unquoted.hpp:5:26
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m     sizes[] = { 0, "1", "[0m[36m(8-7)/3[0m"}; // 0 and "1" ignored, 3rd is reducible
+  [0m[36m│[0m                          [0m[36m^^^^^^^[0m [0m[36mreducible to: 0.33333334[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: Could remove quotes to allow evaluation at build-time


### PR DESCRIPTION
Adds pedantic lint for quoted math statements that hemtt could handle

```
help[L-C12]: Math could be unquoted
  ┌─ addons/main/config.cpp:5:28
  │
5 │         requiredVersion = "2 + 0.18";
  │                            ^^^^^^^^ reducible to: 2.18
  │
  = note: Could remove quotes to allow evaluation at build-time
```