### PR TITLE
preprocessor: detect circular includes

### DIFF
--- a/libs/preprocessor/src/codes/pe29_circular_include.rs
+++ b/libs/preprocessor/src/codes/pe29_circular_include.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use hemtt_workspace::{reporting::{Code, Diagnostic, Label, Token}, WorkspacePath};
+
+use crate::Error;
+
+/// An include was not found
+pub struct CircularInclude {
+    /// The target that was not found
+    token: Vec<Token>,
+    stack: Vec<WorkspacePath>,
+}
+
+impl Code for CircularInclude {
+    fn ident(&self) -> &'static str {
+        "PE29"
+    }
+
+    fn message(&self) -> String {
+        "circular include detected".to_string()
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        let first = self.token.first()?;
+        let last = self.token.last()?;
+        Some(
+            Diagnostic::new(self.ident(), self.message()).with_label(
+                Label::primary(
+                    first.position().path().clone(),
+                    first.position().span().start..last.position().span().end,
+                )
+                .with_message(self.label_message()),
+            ).with_note(
+                format!(
+                        "include stack: {}",
+                    if self.stack.len() > 1 {
+                        format!(
+                            "\n ┬ {}\n ╰ {}",
+                            self.stack
+                                .iter()
+                                .take(self.stack.len() - 1)
+                                .map(std::string::ToString::to_string)
+                                .collect::<Vec<String>>()
+                                .join("\n ├ ")
+                                .as_str(),
+                            self.stack.last().map(std::string::ToString::to_string).unwrap_or_default()
+                        )
+                    } else {
+                        self.stack.first().map(std::string::ToString::to_string).unwrap_or_default()
+                    }
+                )
+            )
+        )
+    }
+}
+
+impl CircularInclude {
+    #[must_use]
+    pub fn new(token: Vec<Arc<Token>>, stack: Vec<WorkspacePath>) -> Self {
+        Self {
+            token: token.into_iter().map(|t| t.as_ref().clone()).collect(),
+            stack,
+        }
+    }
+
+    #[must_use]
+    pub fn code(token: Vec<Arc<Token>>, stack: Vec<WorkspacePath>) -> Error {
+        Error::Code(Arc::new(Self::new(token, stack)))
+    }
+}

--- a/libs/preprocessor/tests/errors.rs
+++ b/libs/preprocessor/tests/errors.rs
@@ -81,3 +81,4 @@ bootstrap!(pe25_exec);
 bootstrap!(pe26_unsupported_builtin);
 bootstrap!(pe27_unexpected_endif);
 bootstrap!(pe28_unexpected_else);
+bootstrap!(pe29_circular_include);

--- a/libs/preprocessor/tests/errors/pe29_circular_include/a.hpp
+++ b/libs/preprocessor/tests/errors/pe29_circular_include/a.hpp
@@ -1,0 +1,1 @@
+#include "b.hpp"

--- a/libs/preprocessor/tests/errors/pe29_circular_include/b.hpp
+++ b/libs/preprocessor/tests/errors/pe29_circular_include/b.hpp
@@ -1,0 +1,1 @@
+#include "a.hpp"

--- a/libs/preprocessor/tests/errors/pe29_circular_include/source.hpp
+++ b/libs/preprocessor/tests/errors/pe29_circular_include/source.hpp
@@ -1,0 +1,1 @@
+#include "a.hpp"

--- a/libs/preprocessor/tests/errors/pe29_circular_include/stderr.ansi
+++ b/libs/preprocessor/tests/errors/pe29_circular_include/stderr.ansi
@@ -1,0 +1,11 @@
+[0m[1m[38;5;9merror[PE29][0m[1m: circular include detected[0m
+  [0m[36m┌─[0m b.hpp:1:11
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m #include "[0m[31ma.hpp[0m"
+  [0m[36m│[0m           [0m[31m^^^^^[0m [0m[31mcircular include detected[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: include stack: 
+           ┬ /source.hpp
+           ├ /a.hpp
+           ╰ /b.hpp
+


### PR DESCRIPTION
Fixes #914 

I can see some rare cases where this is allowed with `#if` and other checks, but I think that's rare enough that this PR is fine instead of crashing