### PR TITLE
config: Have c12 ignore configs that are usually strings

### DIFF
--- a/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
+++ b/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
@@ -94,7 +94,7 @@ impl LintRunner<LintData> for Runner {
         let check_if_equation = !match config.option("forced") {
             Some(toml::Value::Boolean(forced)) => *forced,
             Some(toml::Value::Array(forced)) => forced.iter().map(|v| v.as_str().expect("forced items must be strings").to_lowercase()).any(|x| x == name.as_str()),
-            None => ["initspeed"].contains(&name.as_str()),
+            None => ["initspeed", "ambient", "diffuse", "forceddiffuse", "emmisive", "specular", "specularpower"].contains(&name.as_str()),
             _ => {
                 println!("Invalid forced value on math_could_be_unquoted, expected boolean or array of strings");
                 false

--- a/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
+++ b/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
@@ -34,7 +34,7 @@ impl Lint<LintData> for LintC12MathCouldBeUnquoted {
 ```toml
 [lints.config.math_could_be_unquoted]
 options.ignore = ["text", "name", "displayname"]
-options.forced = ["initSpeed"]
+options.forced = ["initspeed", "ambient", "diffuse", "forceddiffuse", "emmisive", "specular", "specularpower"]
 ```
 
 ### Example

--- a/libs/config/tests/lints/c12_math_could_be_unquoted.hpp
+++ b/libs/config/tests/lints/c12_math_could_be_unquoted.hpp
@@ -5,4 +5,8 @@ class test {
     sizes[] = { 0, "1", "(8-7)/3"}; // 0 and "1" ignored, 3rd is reducible
     opticsZoomInit = "1 call (uiNamespace getVariable 'cba_optics_fnc_setOpticMagnificationHelper')"; // ignore
     myThing[] = {{{{{{{{{"a", "4 + 4"}}}}}}}}};
+    text = "0-9"; // ignored because name
+    class myMagazine {
+        initSpeed = "300"; // forced because name
+    };
 };

--- a/libs/config/tests/snapshots/lints__config_error_c12_math_could_be_unquoted.snap
+++ b/libs/config/tests/snapshots/lints__config_error_c12_math_could_be_unquoted.snap
@@ -27,3 +27,12 @@ expression: lint(stringify! (c12_math_could_be_unquoted))
   [0m[36m│[0m                                [0m[36m^^^^^[0m [0m[36mreducible to: 8[0m
   [0m[36m│[0m
   [0m[36m=[0m [36mnote[0m: Could remove quotes to allow evaluation at build-time
+
+
+[0m[1m[38;5;14mhelp[L-C12][0m[1m: Math could be unquoted[0m
+   [0m[36m┌─[0m c12_math_could_be_unquoted.hpp:10:22
+   [0m[36m│[0m
+[0m[36m10[0m [0m[36m│[0m         initSpeed = "[0m[36m300[0m"; // forced because name
+   [0m[36m│[0m                      [0m[36m^^^[0m [0m[36mreducible to: 300[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: Could remove quotes to allow evaluation at build-time


### PR DESCRIPTION
- `text = "0-9"; // ignored because name`
blocklist "text", "name", "displayname" should reduce any possible false positives

- ` initSpeed = "300"; // forced because name`
not sure about this part or what entries should be, just an option