### PR TITLE
dev: remove linked dir

### DIFF
--- a/bin/src/modules/file_patching.rs
+++ b/bin/src/modules/file_patching.rs
@@ -63,7 +63,7 @@ impl Module for FilePatching {
         let link = prefix_folder.join(ctx.config().prefix());
         if link.exists() {
             trace!("removing existing symlink at {}", link.display());
-            std::fs::remove_file(&link)?;
+            std::fs::remove_dir(&link)?;
         }
         create_link(&link, ctx.build_folder().expect("build folder exists"))?;
         info!("created symlink to build folder for file patching");


### PR DESCRIPTION
at least on windows this has been giving me problems

```
TRACE ThreadId(01) removing existing symlink at F:\SteamLibrary\steamapps\common\Arma 3\z\test
ERROR ThreadId(01) Failed to execute command:
IO Error: Access is denied. (os error 5)
```