### PR TITLE
sqf: Check for undefined functions, config: Fix checking magazines in other addons

### DIFF
--- a/bin/src/executor.rs
+++ b/bin/src/executor.rs
@@ -55,6 +55,7 @@ impl Executor {
     /// The exeuctor will run the `build` phases
     pub fn build(&mut self, write: bool) {
         self.stages.push("pre_build");
+        self.stages.push("pre_build2");
         if write {
             self.stages.push("build");
             self.stages.push("post_build");
@@ -75,21 +76,13 @@ impl Executor {
     /// # Errors
     /// [`Error`] depending on the modules
     pub fn run(&mut self) -> Result<Report, Error> {
-        self.modules.sort_by(|a, b| {
-            if a.name() == "Stringtables" {
-                std::cmp::Ordering::Greater
-            } else if b.name() == "Stringtables" {
-                std::cmp::Ordering::Less
-            } else {
-                std::cmp::Ordering::Equal
-            }
-        });
         let mut report = Report::new();
         for stage in self.stages.clone() {
             report.merge(match stage {
                 "init" => self.run_modules("init")?,
                 "check" => self.run_modules("check")?,
                 "pre_build" => self.run_modules("pre_build")?,
+                "pre_build2" => self.run_modules("pre_build2")?,
                 "build" => {
                     trace!("phase: build (start)");
                     let report = modules::pbo::build(&self.ctx, self.collapse)?;
@@ -123,6 +116,7 @@ impl Executor {
                 "init" => module.init(&self.ctx)?,
                 "check" => module.check(&self.ctx)?,
                 "pre_build" => module.pre_build(&self.ctx)?,
+                "pre_build2" => module.pre_build2(&self.ctx)?,
                 "post_build" => module.post_build(&self.ctx)?,
                 "pre_release" => module.pre_release(&self.ctx)?,
                 "archive" => module.archive(&self.ctx)?,

--- a/bin/src/modules/mod.rs
+++ b/bin/src/modules/mod.rs
@@ -47,6 +47,13 @@ pub trait Module {
     fn pre_build(&self, _ctx: &Context) -> Result<Report, Error> {
         Ok(Report::new())
     }
+    /// Executes the module's `pre_build: Episode II` phase
+    ///
+    /// # Errors
+    /// Any error that the module encounters
+    fn pre_build2(&self, _ctx: &Context) -> Result<Report, Error> {
+        Ok(Report::new())
+    }
     /// Executes the module's `post_build` phase
     ///
     /// # Errors

--- a/bin/src/modules/rapifier.rs
+++ b/bin/src/modules/rapifier.rs
@@ -148,6 +148,12 @@ pub fn rapify(addon: &Addon, path: &WorkspacePath, ctx: &Context) -> Result<Repo
                 .iter()
                 .map(|(s, p)| (s.to_owned(), p.clone())),
         );
+    addon
+        .build_data()
+        .functions_defined()
+        .lock()
+        .expect("not poisoned")
+        .extend(configreport.functions_defined().clone());
     configreport.notes_and_helps().into_iter().for_each(|e| {
         report.push(e.clone());
     });

--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -102,24 +102,7 @@ impl Module for SQFCompiler {
                             database.clone(),
                         );
                         if let Some(sqf_report) = sqf_report {
-                            addon
-                                .build_data()
-                                .localizations()
-                                .lock()
-                                .expect("not poisoned")
-                                .extend(sqf_report.localizations);
-                            addon
-                                .build_data()
-                                .functions_used()
-                                .lock()
-                                .expect("not poisoned")
-                                .extend(sqf_report.functions_used);
-                            addon
-                                .build_data()
-                                .functions_defined()
-                                .lock()
-                                .expect("not poisoned")
-                                .extend(sqf_report.functions_defined);
+                            sqf_report.push_to_addon(addon);
                         };
                         if !codes.failed() {
                             let mut out = entry.with_extension("sqfc")?.create_file()?;

--- a/bin/src/modules/stringtables.rs
+++ b/bin/src/modules/stringtables.rs
@@ -42,7 +42,7 @@ impl Module for Stringtables {
         Ok(report)
     }
 
-    fn pre_build(&self, ctx: &Context) -> Result<Report, Error> {
+    fn pre_build2(&self, ctx: &Context) -> Result<Report, Error> {
         let report = Arc::new(Mutex::new(Report::new()));
         let mut paths = Vec::new();
         for root in ["addons", "optionals"] {

--- a/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
+++ b/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
@@ -2,6 +2,7 @@ use std::{ops::Range, sync::Arc};
 
 use hemtt_common::config::{LintConfig, ProjectConfig};
 use hemtt_workspace::{
+    addons::Addon,
     lint::{AnyLintRunner, Lint, LintRunner},
     reporting::{Code, Codes, Diagnostic, Label, Processed, Severity},
 };
@@ -24,7 +25,7 @@ impl Lint<LintData> for LintC09MagwellMissingMagazine {
     }
 
     fn documentation(&self) -> &'static str {
-r#"### Example
+        r#"### Example
 
 **Incorrect**
 ```hpp
@@ -63,7 +64,6 @@ class CfgMagazines {
 
 Magazines defined in `CfgMagazineWells` that are using the project's prefix (abe in this case) must be defined in `CfgMagazines` as well. This is to prevent accidental typos or forgotten magazines.
 "#
-
     }
 
     fn default_config(&self) -> LintConfig {
@@ -75,12 +75,12 @@ Magazines defined in `CfgMagazineWells` that are using the project's prefix (abe
     }
 
     fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
-        vec![Box::new(Runner)]
+        vec![Box::new(RunnerScan), Box::new(RunnerFinal)]
     }
 }
 
-struct Runner;
-impl LintRunner<LintData> for Runner {
+struct RunnerScan;
+impl LintRunner<LintData> for RunnerScan {
     type Target = Config;
     fn run(
         &self,
@@ -88,84 +88,125 @@ impl LintRunner<LintData> for Runner {
         _config: &LintConfig,
         processed: Option<&Processed>,
         target: &Config,
-        _data: &LintData,
+        data: &LintData,
     ) -> Codes {
         let Some(processed) = processed else {
             return vec![];
         };
-        let mut codes: Codes = Vec::new();
+        let mut codes = Vec::new();
         let mut classes = Vec::new();
-        let Some(Property::Class(Class::Local {
-            properties: magwells,
-            ..
-        })) = target
-            .0
-            .iter()
-            .find(|p| p.name().value.to_lowercase() == "cfgmagazinewells")
-        else {
-            return codes;
-        };
-        let Some(Property::Class(Class::Local {
+
+        if let Some(Property::Class(Class::Local {
             properties: magazines,
             ..
         })) = target
             .0
             .iter()
             .find(|p| p.name().value.to_lowercase() == "cfgmagazines")
-        else {
-            return codes;
-        };
-        for property in magazines {
-            if let Property::Class(Class::Local { name, .. }) = property {
-                classes.push(name);
+        {
+            for property in magazines {
+                if let Property::Class(Class::Local { name, .. }) = property {
+                    classes.push(name);
+                }
             }
-        }
-        for magwell in magwells {
-            let Property::Class(Class::Local {
-                properties: addons, ..
-            }) = magwell
-            else {
-                continue;
-            };
-            for addon in addons {
-                let Property::Entry {
-                    name,
-                    value: Value::Array(magazines),
-                    ..
-                } = addon
+        };
+
+        if let Some(Property::Class(Class::Local {
+            properties: magwells,
+            ..
+        })) = target
+            .0
+            .iter()
+            .find(|p| p.name().value.to_lowercase() == "cfgmagazinewells")
+        {
+            for magwell in magwells {
+                let Property::Class(Class::Local {
+                    properties: addons, ..
+                }) = magwell
                 else {
                     continue;
                 };
-                for mag in &magazines.items {
-                    let Item::Str(Str { value, span }) = mag else {
+                for addon in addons {
+                    let Property::Entry {
+                        name,
+                        value: Value::Array(magazines),
+                        ..
+                    } = addon
+                    else {
                         continue;
                     };
-                    if let Some(project) = project {
-                        if !value
-                            .to_lowercase()
-                            .starts_with(&project.prefix().to_lowercase())
-                        {
+                    for mag in &magazines.items {
+                        let Item::Str(Str { value, span }) = mag else {
                             continue;
+                        };
+                        if let Some(project) = project {
+                            if !value
+                                .to_lowercase()
+                                .starts_with(&project.prefix().to_lowercase())
+                            {
+                                continue;
+                            }
                         }
-                    }
-                    if !classes.iter().any(|c| c.value == *value) {
-                        codes.push(Arc::new(Code09MagwellMissingMagazine::new(
-                            name.clone(),
-                            span.clone(),
-                            processed,
-                        )));
+                        if !classes.iter().any(|c| c.value == *value) {
+                            let code: Arc<dyn Code> = Arc::new(Code09MagwellMissingMagazine::new(
+                                name.clone(),
+                                span.clone(),
+                                processed,
+                            ));
+                            codes.push((value.clone(), code));
+                        }
                     }
                 }
             }
+        };
+        {
+        let mut magazine_well_error_info = data.magazine_well_info.lock().expect("mutex safety");
+        magazine_well_error_info
+            .0
+            .extend(classes.iter().map(|i| i.as_str().to_string()));
+        magazine_well_error_info.1.extend(codes);
         }
-        codes
+        vec![]
+    }
+}
+
+/// Runner for finale during `pre_build2`
+struct RunnerFinal;
+impl LintRunner<LintData> for RunnerFinal {
+    type Target = Vec<Addon>;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        _config: &LintConfig,
+        _processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let mut all_magazines = Vec::new();
+        let mut all_codes = Vec::new();
+
+        for addon in target {
+            let (mags, magwell_codes) = addon
+                .build_data()
+                .magazine_well_info()
+                .lock()
+                .expect("not poision")
+                .clone();
+            all_magazines.extend(mags);
+            all_codes.extend(magwell_codes);
+        }
+        all_codes
+            .iter()
+            .filter(|(missing_mag, _)| !all_magazines.iter().any(|c| c == missing_mag))
+            .map(|(_, code)| code.clone())
+            .collect()
     }
 }
 
 pub struct Code09MagwellMissingMagazine {
     array: Ident,
     span: Range<usize>,
-
     diagnostic: Option<Diagnostic>,
 }
 
@@ -199,7 +240,6 @@ impl Code09MagwellMissingMagazine {
         Self {
             array,
             span,
-
             diagnostic: None,
         }
         .diagnostic_generate_processed(processed)

--- a/libs/config/src/analyze/lints/collect_cfgfunctions.rs
+++ b/libs/config/src/analyze/lints/collect_cfgfunctions.rs
@@ -1,0 +1,85 @@
+use hemtt_common::config::{LintConfig, ProjectConfig};
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Codes, Processed},
+};
+
+use crate::{analyze::LintData, Class, Config, Property, Value};
+
+crate::analyze::lint!(LintColectCfgFunctions);
+
+impl Lint<LintData> for LintColectCfgFunctions {
+    fn display(&self) -> bool {
+        false
+    }
+
+    fn ident(&self) -> &'static str {
+        "collect_cfgfunctions"
+    }
+
+    fn sort(&self) -> u32 {
+        0
+    }
+
+    fn description(&self) -> &'static str {
+        "collect_cfgfunctions"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"This should not be visable"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::warning()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Config;
+    fn run(
+        &self,
+        _project: Option<&ProjectConfig>,
+        _config: &LintConfig,
+        _processed: Option<&Processed>,
+        target: &Config,
+        data: &LintData,
+    ) -> Codes {
+        let Some(Property::Class(Class::Local {
+            properties: prefices_properties,
+            ..
+        })) = target
+            .0
+            .iter()
+            .find(|p| p.name().value.to_lowercase() == "cfgfunctions")
+        else {
+            return Vec::new();
+        };
+        for prefix in prefices_properties {
+            let Property::Class(Class::Local { name: tag_name, properties: tag_properties, .. }) = prefix else { continue };
+            let mut prefix_real = tag_name.as_str();
+            for p in tag_properties {
+                let Property::Entry { name, value, .. } = p else { continue };
+                if name.as_str().to_lowercase() != "tag" { continue; }
+                let Value::Str(value) = value else { continue; };
+                prefix_real = value.value();
+            }
+            for p in tag_properties {
+                let Property::Class(class) = p else { continue };
+                let Class::Local { properties: properties_category, .. } = class else { continue };
+                for function in properties_category {
+                    let Property::Class(Class::Local { name: class_name, .. }) = function else { continue };
+                    let func_name = format!("{prefix_real}_fnc_{}",class_name.as_str()).to_lowercase();
+                    let mut functions_defined = data.functions_defined.lock().expect("mutex safety");
+                    functions_defined.insert(func_name);
+                }
+            }
+        }
+        Vec::new()
+    }
+}

--- a/libs/config/src/analyze/mod.rs
+++ b/libs/config/src/analyze/mod.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
 
 use hemtt_common::config::ProjectConfig;
 use hemtt_workspace::{
@@ -15,9 +18,11 @@ pub mod lints {
     automod::dir!(pub "src/analyze/lints");
 }
 
+pub type DefinedFunctions = HashSet<String>;
 pub struct LintData {
     pub(crate) path: String,
     pub(crate) localizations: Arc<Mutex<Vec<(String, Position)>>>,
+    pub(crate) functions_defined: Arc<Mutex<DefinedFunctions>>,
 }
 
 lint_manager!(config, vec![]);
@@ -85,6 +90,7 @@ impl Analyze for Class {
                         |name| format!("{}/{}", data.path, name.value),
                     ),
                     localizations: data.localizations.clone(),
+                    functions_defined: data.functions_defined.clone(),
                 };
                 properties
                     .iter()
@@ -111,6 +117,7 @@ impl Analyze for Property {
                 let data = LintData {
                     path: format!("{}.{}", data.path, self.name().value),
                     localizations: data.localizations.clone(),
+                    functions_defined: data.functions_defined.clone(),
                 };
                 value.analyze(&data, project, processed, manager)
             }

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -103,7 +103,7 @@ pub struct ConfigReport {
     patches: Vec<CfgPatch>,
     localized: Vec<(String, Position)>,
     functions_defined: DefinedFunctions,
-    magazine_well_info: MagazineWellInfo,
+    pub magazine_well_info: MagazineWellInfo,
 }
 
 impl ConfigReport {

--- a/libs/config/tests/snapshots/lints__c09_magwell_missing_magazine.snap
+++ b/libs/config/tests/snapshots/lints__c09_magwell_missing_magazine.snap
@@ -1,0 +1,5 @@
+---
+source: libs/config/tests/lints.rs
+expression: report.magazine_well_info
+---
+(["abe_cavendish"], [("abe_plantain", L-C09)])

--- a/libs/config/tests/snapshots/lints__config_error_c09_magwell_missing_magazine.snap
+++ b/libs/config/tests/snapshots/lints__config_error_c09_magwell_missing_magazine.snap
@@ -2,11 +2,4 @@
 source: libs/config/tests/lints.rs
 expression: lint(stringify! (c09_magwell_missing_magazine))
 ---
-[0m[1m[38;5;9merror[L-C09][0m[1m: magazine defined in CfgMagazineWells was not found in CfgMagazines[0m
-  [0m[36m┌─[0m c09_magwell_missing_magazine.hpp:5:13
-  [0m[36m│[0m
-[0m[36m3[0m [0m[36m│[0m         abe_main[] = {
-  [0m[36m│[0m         [0m[36m--------[0m [0m[36mmagazine well defined here[0m
-[0m[36m4[0m [0m[36m│[0m             "abe_cavendish",
-[0m[36m5[0m [0m[36m│[0m             [0m[31m"abe_plantain"[0m,
-  [0m[36m│[0m             [0m[31m^^^^^^^^^^^^^^[0m [0m[31mno matching magazine was found[0m
+

--- a/libs/sqf/src/analyze/lints/s01_command_required_version.rs
+++ b/libs/sqf/src/analyze/lints/s01_command_required_version.rs
@@ -69,7 +69,7 @@ impl LintRunner<LintData> for Runner {
         let Some(processed) = processed else {
             return Vec::new();
         };
-        let Some(required) = data.addon.build_data().required_version() else {
+        let Some(required) = data.addon.as_ref().expect("addon will exist").build_data().required_version() else {
             // TODO what to do here?
             return Vec::new();
         };

--- a/libs/sqf/src/analyze/lints/s02_event_handlers.rs
+++ b/libs/sqf/src/analyze/lints/s02_event_handlers.rs
@@ -197,7 +197,7 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
                     config.get("event_unknown"),
                 ));
                 codes.extend(check_version(
-                    &data.addon, &ns, &name, &id, &eh, processed, &data.database,
+                    data.addon.as_ref().expect("addon will exist"), &ns, &name, &id, &eh, processed, &data.database,
                 ));
             }
         }

--- a/libs/sqf/src/analyze/lints/s29_function_undefined.rs
+++ b/libs/sqf/src/analyze/lints/s29_function_undefined.rs
@@ -1,0 +1,288 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+    vec,
+};
+
+use hemtt_common::config::{LintConfig, ProjectConfig};
+use hemtt_workspace::{
+    addons::Addon,
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Severity},
+};
+use toml::Value;
+
+use crate::{analyze::LintData, BinaryCommand, Expression, Statement};
+
+crate::analyze::lint!(CollectFunctions);
+
+impl Lint<LintData> for CollectFunctions {
+    fn display(&self) -> bool {
+        false
+    }
+
+    fn ident(&self) -> &'static str {
+        "function_undefined"
+    }
+
+    fn sort(&self) -> u32 {
+        290
+    }
+
+    fn description(&self) -> &'static str {
+        "Using undefined functions is bad"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Configuration
+
+- **ignore**: An funcs to ignore
+
+```toml
+[lints.sqf.function_undefined]
+options.ignore = [
+    "myproject_fnc_piano",
+]
+```
+
+### Explanation
+
+Checks for usage of undefined functions"#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::warning()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![
+            Box::new(RunnerExpression),
+            Box::new(RunnerStatement),
+            Box::new(RunnerFinal),
+        ]
+    }
+}
+
+fn is_project_func(var: &str, project: &ProjectConfig) -> bool {
+    let prefix = project.prefix();
+    var.starts_with(prefix) && var.contains("_fnc_")
+}
+/// Runner for Expression (Var usage and calls to CBA's compile funcs)
+struct RunnerExpression;
+impl LintRunner<LintData> for RunnerExpression {
+    type Target = crate::Expression;
+
+    fn run(
+        &self,
+        project: Option<&hemtt_common::config::ProjectConfig>,
+        _config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Self::Target,
+        data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        let Some(project) = project else {
+            return Vec::new();
+        };
+        match target {
+            Expression::Variable(var_name, var_span) => {
+                let var_name = var_name.to_lowercase();
+                if is_project_func(&var_name, project) {
+                    let pos = if let Some(mapping) = processed.mapping(var_span.start) {
+                        mapping.token().position().clone()
+                    } else {
+                        // No position found for token?
+                        return vec![];
+                    };
+                    let mut used_functions = data.functions_used.lock().expect("mutex safety");
+                    used_functions.push((var_name, pos));
+                }
+            }
+            Expression::BinaryCommand(BinaryCommand::Named(cmd), lhs, rhs, _span) => {
+                if cmd.to_lowercase() != "call" {
+                    return Vec::new();
+                }
+                let Expression::Variable(rhs_name, _) = &**rhs else {
+                    return vec![];
+                };
+                let Expression::Array(lhs_arr, _) = &**lhs else {
+                    return vec![];
+                };
+                // funcs have different arg order but do have same arg length
+                if lhs_arr.len() < 2 {
+                    return vec![];
+                }
+                let func_name = match rhs_name.to_lowercase().as_str() {
+                    "cba_fnc_compilefinal" => {
+                        let Expression::String(func_name, _, _) = &lhs_arr[0] else {
+                            return vec![];
+                        };
+                        func_name
+                    }
+                    "cba_fnc_compilefunction" | "slx_xeh_compile_new" => {
+                        let Expression::String(func_name, _, _) = &lhs_arr[1] else {
+                            return vec![];
+                        };
+                        func_name
+                    }
+                    _ => {
+                        return vec![];
+                    }
+                };
+                let func_name = func_name.to_lowercase();
+                if is_project_func(&func_name, project) {
+                    let mut functions_defined =
+                        data.functions_defined.lock().expect("mutex safety");
+                    functions_defined.insert(func_name);
+                }
+            }
+            _ => {}
+        }
+
+        vec![]
+    }
+}
+
+/// Runner for Statement (Var Assignment)
+struct RunnerStatement;
+impl LintRunner<LintData> for RunnerStatement {
+    type Target = crate::Statement;
+
+    fn run(
+        &self,
+        project: Option<&hemtt_common::config::ProjectConfig>,
+        _config: &LintConfig,
+        _processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Self::Target,
+        data: &LintData,
+    ) -> Codes {
+        let Some(project) = project else {
+            return Vec::new();
+        };
+        let Statement::AssignGlobal(func_name, _, _) = target else {
+            return Vec::new();
+        };
+        let func_name = func_name.to_lowercase();
+        if is_project_func(&func_name, project) {
+            let mut functions_defined = data.functions_defined.lock().expect("mutex safety");
+            functions_defined.insert(func_name);
+        }
+
+        vec![]
+    }
+}
+
+/// Runner for finale during `pre_build2`
+struct RunnerFinal;
+impl LintRunner<LintData> for RunnerFinal {
+    type Target = Vec<Addon>;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        _processed: Option<&hemtt_workspace::reporting::Processed>,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let mut codes: Codes = Vec::new();
+        let mut all_defined = HashSet::new();
+        for addon in target {
+            let defined = addon
+                .build_data()
+                .functions_defined()
+                .lock()
+                .expect("not romeo")
+                .clone();
+            all_defined.extend(defined);
+        }
+
+        if let Some(toml::Value::Array(ignore)) = config.option("ignore") {
+            for i in ignore {
+                if let Value::String(i) = i {
+                    all_defined.insert(i.to_lowercase());
+                };
+            }
+        }
+
+        let mut all_missing = BTreeMap::new();
+        for addon in target {
+            let used = addon
+                .build_data()
+                .functions_used()
+                .lock()
+                .expect("not juliet")
+                .clone();
+            for (func, span) in used {
+                if !all_defined.contains(&func) {
+                    all_missing.entry(func).or_insert(Vec::new()).push(span);
+                }
+            }
+        }
+
+        for (func, spans) in all_missing {
+            let joined = spans
+                .iter()
+                .map(|s| format!("{}:{}:{}", s.path(), s.start().line(), s.start().column()))
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            codes.push(Arc::new(Code29FunctionUndefined::new(
+                func,
+                joined,
+                config.severity(),
+            )));
+        }
+
+        codes
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct Code29FunctionUndefined {
+    func_name: String,
+    spans: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for Code29FunctionUndefined {
+    fn ident(&self) -> &'static str {
+        "L-S29"
+    }
+    fn link(&self) -> Option<&str> {
+        Some("/analysis/sqf.html#function_undefined")
+    }
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+    fn message(&self) -> String {
+        format!("Undefined Function: {}", self.func_name)
+    }
+    fn note(&self) -> Option<String> {
+        Some(format!("Used in:\n{}", self.spans))
+    }
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl Code29FunctionUndefined {
+    #[must_use]
+    pub fn new(func_name: String, spans: String, severity: Severity) -> Self {
+        Self {
+            func_name,
+            spans,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed()
+    }
+
+    fn generate_processed(mut self) -> Self {
+        self.diagnostic = Some(Diagnostic::from_code(&self));
+        self
+    }
+}

--- a/libs/sqf/src/analyze/mod.rs
+++ b/libs/sqf/src/analyze/mod.rs
@@ -2,7 +2,10 @@ pub mod lints {
     automod::dir!(pub "src/analyze/lints");
 }
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
 
 use hemtt_common::config::ProjectConfig;
 use hemtt_workspace::{
@@ -45,7 +48,7 @@ pub fn analyze(
     processed: &Processed,
     addon: Arc<Addon>,
     database: Arc<Database>,
-) -> (Codes, Localizations) {
+) -> (Codes, Option<SqfReport>) {
     let default_enabled = project.is_some_and(|p| p.runtime().is_pedantic());
     let mut manager: LintManager<LintData> = LintManager::new(
         project.map_or_else(Default::default, |project| project.lints().sqf().clone()),
@@ -54,7 +57,7 @@ pub fn analyze(
         SQF_LINTS.iter().map(|l| (**l).clone()).collect::<Vec<_>>(),
         default_enabled,
     ) {
-        return (lint_errors, vec![]);
+        return (lint_errors, None);
     }
     if let Err(lint_errors) = manager.push_group(
         vec![
@@ -65,33 +68,60 @@ pub fn analyze(
         Box::new(EventHandlerRunner),
         default_enabled,
     ) {
-        return (lint_errors, vec![]);
+        return (lint_errors, None);
     }
     let localizations = Arc::new(Mutex::new(vec![]));
+    let functions_used = Arc::new(Mutex::new(vec![]));
+    let functions_defined = Arc::new(Mutex::new(HashSet::new()));
     let codes = statements.analyze(
         &LintData {
-            addon,
+            addon: Some(addon),
             database,
             localizations: localizations.clone(),
+            functions_used: functions_used.clone(),
+            functions_defined: functions_defined.clone(),
         },
         project,
         processed,
         &manager,
     );
+
+    let localizations = Arc::<Mutex<Localizations>>::try_unwrap(localizations)
+        .expect("not poisoned")
+        .into_inner()
+        .expect("not poisoned");
+    let functions_used = Arc::<Mutex<UsedFunctions>>::try_unwrap(functions_used)
+        .expect("not poisoned")
+        .into_inner()
+        .expect("not poisoned");
+    let functions_defined = Arc::<Mutex<DefinedFunctions>>::try_unwrap(functions_defined)
+        .expect("not poisoned")
+        .into_inner()
+        .expect("not poisoned");
     (
         codes,
-        Arc::<Mutex<Vec<(String, Position)>>>::try_unwrap(localizations)
-            .expect("not poisoned")
-            .into_inner()
-            .expect("not poisoned"),
+        Some(SqfReport {
+            localizations,
+            functions_used,
+            functions_defined,
+        }),
     )
 }
 
 pub type Localizations = Vec<(String, Position)>;
+pub type UsedFunctions = Vec<(String, Position)>;
+pub type DefinedFunctions = HashSet<String>;
 pub struct LintData {
-    pub(crate) addon: Arc<Addon>,
+    pub(crate) addon: Option<Arc<Addon>>,
     pub(crate) database: Arc<Database>,
     pub(crate) localizations: Arc<Mutex<Localizations>>,
+    pub(crate) functions_used: Arc<Mutex<UsedFunctions>>,
+    pub(crate) functions_defined: Arc<Mutex<DefinedFunctions>>,
+}
+pub struct SqfReport {
+    pub localizations: Localizations,
+    pub functions_used: UsedFunctions,
+    pub functions_defined: DefinedFunctions,
 }
 
 pub trait Analyze: Sized + 'static {
@@ -203,4 +233,36 @@ fn extract_constant(expression: &Expression) -> Option<(String, bool)> {
         }
     }
     None
+}
+
+#[must_use]
+#[allow(clippy::ptr_arg)]
+pub fn lint_all(
+    project_config: Option<&ProjectConfig>,
+    addons: &Vec<Addon>,
+    database: Arc<Database>,
+) -> Codes {
+    let default_enabled = project_config.is_some_and(|p| p.runtime().is_pedantic());
+    let mut manager = LintManager::new(
+        project_config.map_or_else(Default::default, |project| project.lints().sqf().clone()),
+    );
+    if let Err(e) = manager.extend(
+        SQF_LINTS.iter().map(|l| (**l).clone()).collect::<Vec<_>>(),
+        default_enabled,
+    ) {
+        return e;
+    }
+
+    manager.run(
+        &LintData {
+            addon: None,
+            database,
+            localizations: Arc::new(Mutex::new(vec![])),
+            functions_used: Arc::new(Mutex::new(vec![])),
+            functions_defined: Arc::new(Mutex::new(HashSet::new())),
+        },
+        project_config,
+        None,
+        addons,
+    )
 }

--- a/libs/sqf/src/analyze/mod.rs
+++ b/libs/sqf/src/analyze/mod.rs
@@ -125,7 +125,7 @@ pub struct SqfReport {
 impl SqfReport {
     /// Pushes the report into an Addon
     /// # Panics
-        pub fn push_to_addon(&self, addon: &Addon) {
+    pub fn push_to_addon(&self, addon: &Addon) {
         let build_data = addon.build_data();
         build_data
             .localizations()

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -46,13 +46,11 @@ lint!(s27_select_count);
 lint!(s28_banned_macros);
 
 #[test]
-fn test_s29() {
+fn test_s29_function_undefined() {
     let (_, report) = lint(stringify!(s29_undefined_functions));
-
     assert!(report.functions_defined.contains("test_fnc_a"));
     assert!(report.functions_defined.contains("test_fnc_b"));
     assert!(report.functions_defined.contains("test_fnc_c"));
-
     assert!(report.functions_used.iter().any(|x| x.0 == "test_fnc_x"));
     assert!(report.functions_used.iter().any(|x| x.0 == "test_fnc_y"));
 }

--- a/libs/sqf/tests/lints/s29_undefined_functions.sqf
+++ b/libs/sqf/tests/lints/s29_undefined_functions.sqf
@@ -1,0 +1,6 @@
+test_fnc_A = {1};
+["test_fnc_b", {2}] call cba_fnc_compilefinal;
+["file", "test_fnc_C"] call cba_fnc_compilefunction;
+
+[] call test_fnc_x;
+[] spawn test_fnc_Y;

--- a/libs/stringtable/src/analyze/mod.rs
+++ b/libs/stringtable/src/analyze/mod.rs
@@ -36,6 +36,7 @@ pub fn lint_one(
 }
 
 #[allow(clippy::ptr_arg)] // Needed for &Vec for &dyn Any
+#[must_use]
 pub fn lint_all(
     projects: &Vec<Project>,
     project_config: Option<&ProjectConfig>,

--- a/libs/workspace/src/addons.rs
+++ b/libs/workspace/src/addons.rs
@@ -12,6 +12,7 @@ use tracing::{trace, warn};
 
 use crate::WorkspacePath;
 use crate::position::Position;
+use crate::reporting::Code;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum Error {
@@ -236,6 +237,9 @@ impl Display for Location {
 }
 
 type RequiredVersion = (Version, WorkspacePath, Range<usize>);
+pub type UsedFunctions = Vec<(String, Position)>;
+pub type DefinedFunctions = HashSet<String>;
+pub type MagazineWellInfo = (Vec<String>, Vec<(String, Arc<dyn Code>)>);
 
 #[derive(Debug, Clone, Default)]
 pub struct BuildData {
@@ -243,6 +247,7 @@ pub struct BuildData {
     localizations: Arc<Mutex<Vec<(String, Position)>>>,
     functions_defined: Arc<Mutex<HashSet<String>>>,
     functions_used: Arc<Mutex<Vec<(String, Position)>>>,
+    magazine_well_info: Arc<Mutex<MagazineWellInfo>>,
 }
 
 impl BuildData {
@@ -253,6 +258,7 @@ impl BuildData {
             localizations: Arc::new(Mutex::new(Vec::new())),
             functions_defined: Arc::new(Mutex::new(HashSet::new())),
             functions_used: Arc::new(Mutex::new(Vec::new())),
+            magazine_well_info: Arc::new(Mutex::new((Vec::new(), Vec::new()))),
         }
     }
 
@@ -289,13 +295,18 @@ impl BuildData {
     }
     #[must_use]
     /// Fetches the used functions
-    pub fn functions_used(&self) -> Arc<Mutex<Vec<(String, Position)>>> {
+    pub fn functions_used(&self) -> Arc<Mutex<UsedFunctions>> {
         self.functions_used.clone()
     }
     #[must_use]
     /// Fetches the used functions
-    pub fn functions_defined(&self) -> Arc<Mutex<HashSet<String>>> {
+    pub fn functions_defined(&self) -> Arc<Mutex<DefinedFunctions>> {
         self.functions_defined.clone()
+    }
+    #[must_use]
+    /// Fetches the used functions
+    pub fn magazine_well_info(&self) -> Arc<Mutex<MagazineWellInfo>> {
+        self.magazine_well_info.clone()
     }
 }
 

--- a/libs/workspace/src/addons.rs
+++ b/libs/workspace/src/addons.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -240,6 +241,8 @@ type RequiredVersion = (Version, WorkspacePath, Range<usize>);
 pub struct BuildData {
     required_version: Arc<RwLock<Option<RequiredVersion>>>,
     localizations: Arc<Mutex<Vec<(String, Position)>>>,
+    functions_defined: Arc<Mutex<HashSet<String>>>,
+    functions_used: Arc<Mutex<Vec<(String, Position)>>>,
 }
 
 impl BuildData {
@@ -248,6 +251,8 @@ impl BuildData {
         Self {
             required_version: Arc::new(RwLock::new(None)),
             localizations: Arc::new(Mutex::new(Vec::new())),
+            functions_defined: Arc::new(Mutex::new(HashSet::new())),
+            functions_used: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -281,6 +286,16 @@ impl BuildData {
     /// Fetches the localizations
     pub fn localizations(&self) -> Arc<Mutex<Vec<(String, Position)>>> {
         self.localizations.clone()
+    }
+    #[must_use]
+    /// Fetches the used functions
+    pub fn functions_used(&self) -> Arc<Mutex<Vec<(String, Position)>>> {
+        self.functions_used.clone()
+    }
+    #[must_use]
+    /// Fetches the used functions
+    pub fn functions_defined(&self) -> Arc<Mutex<HashSet<String>>> {
+        self.functions_defined.clone()
     }
 }
 


### PR DESCRIPTION
Adds a pre-build2 phase for lints that need to run after others (e.g. project-wide)

- Check for undefined functions
Gather all defined functions from CfgFunctions
Gather defined and used functions from code
Then durring pre-build2 check for missing
```
warning[L-S29]: Undefined Function: test_fnc_def4
 = note: Used in:
         /addons/main/test.sqf:1:11
         /addons/main/init.sqf:8:11
```

- Fix https://github.com/BrettMayson/HEMTT/issues/866
Gather all defined magazines and (magwell errors and the missing mag that caused it)
Create a list of all magazines in the project
Skip error codes that were for magazines that do exist


