### PR TITLE
Update rapifiable formats to all places where they are mentioned

### DIFF
--- a/bin/src/commands/build.rs
+++ b/bin/src/commands/build.rs
@@ -47,11 +47,12 @@ pub struct BuildArgs {
     #[arg(long, action = clap::ArgAction::SetTrue)]
     /// Do not binarize the project
     ///
-    /// They will be copied directly into the PBO. `config.cpp`, `*.rvmat`, `*.ext` will still be rapified.
+    /// They will be copied directly into the PBO. `config.cpp`, `*.rvmat`, `*.ext`, `*.sqm`,
+    /// `*.fsm`, `*.bikb`, `*.bisurf` will still be rapified.
     /// This can be configured per addon in [`addon.toml`](../configuration/addon#binarize).
     no_bin: bool,
     #[arg(long, action = clap::ArgAction::SetTrue)]
-    /// Do not rapify (cpp, rvmat)
+    /// Do not rapify (cpp, rvmat, ext, sqm, fsm, bikb, bisurf)
     ///
     /// They will be copied directly into the PBO.
     /// This can be configured per addon in [`addon.toml`](../configuration/addon#rapify).

--- a/bin/src/commands/dev.rs
+++ b/bin/src/commands/dev.rs
@@ -63,7 +63,7 @@ pub struct DevArgs {
     /// Include all optional addon folders
     pub(crate) all_optionals: bool,
     #[arg(long, action = clap::ArgAction::SetTrue, verbatim_doc_comment)]
-    /// Do not rapify (cpp, rvmat)
+    /// Do not rapify (cpp, rvmat, ext, sqm, fsm, bikb, bisurf)
     ///
     /// They will be copied directly into the PBO, not .bin version is created.
     pub(crate) no_rap: bool,

--- a/bin/src/utils/bom.rs
+++ b/bin/src/utils/bom.rs
@@ -6,7 +6,9 @@ use crate::Error;
 /// Convert UTF-8 with BOM to UTF-8 without BOM
 pub struct Command {}
 
-const ALLOWED_EXTENSIONS: [&str; 6] = ["sqf", "hpp", "cpp", "rvmat", "ext", "xml"];
+const ALLOWED_EXTENSIONS: [&str; 10] = [
+    "sqf", "hpp", "cpp", "rvmat", "ext", "sqm", "fsm", "bikb", "bisurf", "xml",
+];
 
 /// Execute the bom command
 ///

--- a/hls/languages/config.json
+++ b/hls/languages/config.json
@@ -4,7 +4,10 @@
     "ext",
     "cpp",
     "sqm",
-    "rvmat"
+    "rvmat",
+    "fsm",
+    "bikb",
+    "bisurf"
   ],
   "name": "arma-config",
   "patterns": [

--- a/hls/package.json
+++ b/hls/package.json
@@ -61,7 +61,10 @@
           ".ext",
           ".hpp",
           ".sqm",
-          ".rvmat"
+          ".rvmat",
+          ".fsm",
+          ".bikb",
+          ".bisurf"
         ],
         "filenames": [
           "config.cpp"


### PR DESCRIPTION
There is some documentation where rapifiable config formats are listed, but were not updated in #979. There is also some other code where only some Arma config formats are listed but not all.

- `--help` documentation for `--no-rap`
- Language server "Arma config" file extensions
- Allowed extensions for BOM stripping

This PR updates them all with the complete list of config formats.