### PR TITLE
config: Fix not collecting CfgFunctions defined as extern

### DIFF
--- a/libs/config/src/analyze/lints/collect_cfgfunctions.rs
+++ b/libs/config/src/analyze/lints/collect_cfgfunctions.rs
@@ -73,7 +73,8 @@ impl LintRunner<LintData> for Runner {
                 let Property::Class(class) = p else { continue };
                 let Class::Local { properties: properties_category, .. } = class else { continue };
                 for function in properties_category {
-                    let Property::Class(Class::Local { name: class_name, .. }) = function else { continue };
+                    let Property::Class(func_class) = function else { continue };
+                    let Some(class_name) = func_class.name() else { continue; }; 
                     let func_name = format!("{prefix_real}_fnc_{}",class_name.as_str()).to_lowercase();
                     let mut functions_defined = data.functions_defined.lock().expect("mutex safety");
                     functions_defined.insert(func_name);

--- a/libs/config/tests/lints/collect_cfgfunctions.hpp
+++ b/libs/config/tests/lints/collect_cfgfunctions.hpp
@@ -8,6 +8,7 @@ class CfgFunctions {
     class test_blueberry {
         class someCategory2 {
             class f2 {};
+            class f3; // defined as an external, but will still be collected
         };
     };
 };

--- a/libs/config/tests/snapshots/lints__collect_cfgfunctions.snap
+++ b/libs/config/tests/snapshots/lints__collect_cfgfunctions.snap
@@ -2,4 +2,4 @@
 source: libs/config/tests/lints.rs
 expression: functions_defined
 ---
-["test_apple_fnc_f1", "test_blueberry_fnc_f2"]
+["test_apple_fnc_f1", "test_blueberry_fnc_f2", "test_blueberry_fnc_f3"]


### PR DESCRIPTION
```
        class Interface {
            file = "\x\enh\addons\main\functions\interface";
            class 3DENMinimap;
            class assetBrowser_collapse;
```
it assumed people would do `class 3DENMinimap {};` 
defining them as externals was unexpected (but is valid I guess)