### PR TITLE
fnl - ignore license.txt

### DIFF
--- a/bin/src/modules/fnl.rs
+++ b/bin/src/modules/fnl.rs
@@ -35,7 +35,7 @@ impl Module for FineNewLineCheck {
                 .filter(|e| {
                     e.path()
                         .file_name()
-                        .is_some_and(|f| f.to_ascii_lowercase() != "license.txt")
+                        .is_some_and(|f| !f.eq_ignore_ascii_case("license.txt"))
                 })
                 .map(|e| e.path().to_path_buf())
                 .collect::<Vec<_>>()

--- a/bin/src/modules/fnl.rs
+++ b/bin/src/modules/fnl.rs
@@ -32,6 +32,11 @@ impl Module for FineNewLineCheck {
                         .extension()
                         .is_some_and(|e| TEXT_EXTENSIONS.contains(&e.to_str().unwrap_or_default()))
                 })
+                .filter(|e| {
+                    e.path()
+                        .file_name()
+                        .is_some_and(|f| f.to_ascii_lowercase() != "license.txt")
+                })
                 .map(|e| e.path().to_path_buf())
                 .collect::<Vec<_>>()
         }


### PR DESCRIPTION
Shouldn't really matter but I'd rather not modify licenses (if they need to be included untouched)