### PR TITLE
config: enable c14 by default

### DIFF
--- a/bin/src/commands/check.rs
+++ b/bin/src/commands/check.rs
@@ -27,6 +27,9 @@ pub struct CheckArgs {
     #[arg(long, short = 'p', action = clap::ArgAction::SetTrue)]
     /// Run all lints that are disabled by default (but not explicitly disabled via project config)
     pedantic: bool,
+    #[arg(long, short = 'L', action = clap::ArgAction::Append)]
+    /// Run all lints that are disabled by default (but not explicitly disabled via project config)
+    lints: Vec<String>,
 }
 
 /// Execute the check command
@@ -42,6 +45,16 @@ pub fn execute(cmd: &Command) -> Result<Report, Error> {
 
     if cmd.check.pedantic {
         let runtime = ctx.config().runtime().clone().with_pedantic(true);
+        let config = ctx.config().clone().with_runtime(runtime);
+        ctx = ctx.with_config(config);
+    }
+
+    if !cmd.check.lints.is_empty() {
+        let runtime = ctx
+            .config()
+            .runtime()
+            .clone()
+            .with_explicit_lints(cmd.check.lints.clone());
         let config = ctx.config().clone().with_runtime(runtime);
         ctx = ctx.with_config(config);
     }

--- a/bin/src/commands/check.rs
+++ b/bin/src/commands/check.rs
@@ -28,7 +28,7 @@ pub struct CheckArgs {
     /// Run all lints that are disabled by default (but not explicitly disabled via project config)
     pedantic: bool,
     #[arg(long, short = 'L', action = clap::ArgAction::Append)]
-    /// Run all lints that are disabled by default (but not explicitly disabled via project config)
+    /// Explicit Lints
     lints: Vec<String>,
 }
 

--- a/bin/src/modules/rapifier.rs
+++ b/bin/src/modules/rapifier.rs
@@ -51,10 +51,9 @@ impl Module for Rapifier {
 
     fn check(&self, ctx: &Context) -> Result<Report, Error> {
         let mut report = Report::new();
-        let default_enabled = ctx.config().runtime().is_pedantic();
         report.extend(lint_check(
             ctx.config().lints().config().clone(),
-            default_enabled,
+            ctx.config().runtime().clone(),
         ));
         Ok(report)
     }

--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -46,10 +46,9 @@ impl Module for SQFCompiler {
 
     fn check(&self, ctx: &Context) -> Result<Report, Error> {
         let mut report = Report::new();
-        let default_enabled = ctx.config().runtime().is_pedantic();
         report.extend(lint_check(
             ctx.config().lints().sqf().clone(),
-            default_enabled,
+            ctx.config().runtime().clone(),
         ));
         Ok(report)
     }

--- a/bin/src/modules/stringtables.rs
+++ b/bin/src/modules/stringtables.rs
@@ -37,10 +37,9 @@ impl Module for Stringtables {
 
     fn check(&self, ctx: &crate::context::Context) -> Result<crate::report::Report, crate::Error> {
         let mut report = Report::new();
-        let default_enabled = ctx.config().runtime().is_pedantic();
         report.extend(lint_check(
             ctx.config().lints().stringtables().clone(),
-            default_enabled,
+            ctx.config().runtime().clone(),
         ));
         Ok(report)
     }

--- a/libs/common/src/config/mod.rs
+++ b/libs/common/src/config/mod.rs
@@ -12,7 +12,7 @@ pub use addon::AddonConfig;
 pub use pdrive::PDriveOption;
 pub use project::{
     ProjectConfig,
-    hemtt::launch::LaunchOptions,
+    hemtt::{RuntimeArguments, launch::LaunchOptions},
     lint::{LintConfig, LintConfigOverride, LintEnabled},
 };
 

--- a/libs/common/src/config/project/hemtt/mod.rs
+++ b/libs/common/src/config/project/hemtt/mod.rs
@@ -4,7 +4,7 @@ pub mod dev;
 pub mod launch;
 pub mod release;
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use launch::LaunchOptions;
 use serde::{Deserialize, Serialize};
@@ -58,6 +58,8 @@ pub struct RuntimeArguments {
     is_release: bool,
     is_pedantic: bool,
     is_just: bool,
+
+    explicit_lints: Arc<[String]>,
 }
 
 impl RuntimeArguments {
@@ -67,7 +69,7 @@ impl RuntimeArguments {
     }
 
     #[must_use]
-    pub const fn with_release(self, is_release: bool) -> Self {
+    pub fn with_release(self, is_release: bool) -> Self {
         Self { is_release, ..self }
     }
 
@@ -77,7 +79,7 @@ impl RuntimeArguments {
     }
 
     #[must_use]
-    pub const fn with_pedantic(self, is_pedantic: bool) -> Self {
+    pub fn with_pedantic(self, is_pedantic: bool) -> Self {
         Self {
             is_pedantic,
             ..self
@@ -90,8 +92,21 @@ impl RuntimeArguments {
     }
 
     #[must_use]
-    pub const fn with_just(self, is_just: bool) -> Self {
+    pub fn with_just(self, is_just: bool) -> Self {
         Self { is_just, ..self }
+    }
+
+    #[must_use]
+    pub fn explicit_lints(&self) -> &[String] {
+        &self.explicit_lints
+    }
+
+    #[must_use]
+    pub fn with_explicit_lints(self, explicit_lints: Vec<String>) -> Self {
+        Self {
+            explicit_lints: explicit_lints.into(),
+            ..self
+        }
     }
 }
 

--- a/libs/config/src/analyze/lints/c01_invalid_value.rs
+++ b/libs/config/src/analyze/lints/c01_invalid_value.rs
@@ -63,6 +63,7 @@ impl LintRunner<LintData> for RunnerValue {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Value,
         _data: &LintData,
     ) -> Codes {
@@ -92,6 +93,7 @@ impl LintRunner<LintData> for RunnerItem {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Item,
         _data: &LintData,
     ) -> Codes {

--- a/libs/config/src/analyze/lints/c02_duplicate_property.rs
+++ b/libs/config/src/analyze/lints/c02_duplicate_property.rs
@@ -67,6 +67,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Config,
         _data: &LintData,
     ) -> Codes {

--- a/libs/config/src/analyze/lints/c03_duplicate_classes.rs
+++ b/libs/config/src/analyze/lints/c03_duplicate_classes.rs
@@ -71,6 +71,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Config,
         _data: &LintData,
     ) -> Codes {

--- a/libs/config/src/analyze/lints/c04_external_missing.rs
+++ b/libs/config/src/analyze/lints/c04_external_missing.rs
@@ -67,6 +67,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Config,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c05_external_parent_case.rs
+++ b/libs/config/src/analyze/lints/c05_external_parent_case.rs
@@ -66,6 +66,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Class,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c06_unexpected_array.rs
+++ b/libs/config/src/analyze/lints/c06_unexpected_array.rs
@@ -63,6 +63,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Property,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c07_expected_array.rs
+++ b/libs/config/src/analyze/lints/c07_expected_array.rs
@@ -63,6 +63,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Property,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c08_missing_semicolon.rs
+++ b/libs/config/src/analyze/lints/c08_missing_semicolon.rs
@@ -78,6 +78,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Property,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
+++ b/libs/config/src/analyze/lints/c09_magwell_missing_magazine.rs
@@ -87,6 +87,7 @@ impl LintRunner<LintData> for RunnerScan {
         project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Config,
         data: &LintData,
     ) -> Codes {
@@ -180,6 +181,7 @@ impl LintRunner<LintData> for RunnerFinal {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         _config: &LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/config/src/analyze/lints/c10_class_missing_braces.rs
+++ b/libs/config/src/analyze/lints/c10_class_missing_braces.rs
@@ -68,6 +68,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Property,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c11_file_type.rs
+++ b/libs/config/src/analyze/lints/c11_file_type.rs
@@ -101,6 +101,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Property,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
+++ b/libs/config/src/analyze/lints/c12_math_could_be_unquoted.rs
@@ -72,6 +72,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Property,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c13_config_this_call.rs
+++ b/libs/config/src/analyze/lints/c13_config_this_call.rs
@@ -59,6 +59,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &crate::Value,
         _data: &LintData,
     ) -> Vec<std::sync::Arc<dyn Code>> {

--- a/libs/config/src/analyze/lints/c14_unused_external.rs
+++ b/libs/config/src/analyze/lints/c14_unused_external.rs
@@ -262,7 +262,7 @@ impl Code for CodeC14UnusedExternal {
             self.diagnostic.clone()
         } else if self.first {
             Some(
-                Diagnostic::from_code(self).set_message(format!("There are {count} unused external classes, They have been written to {PATH}"))
+                Diagnostic::from_code(self).set_message(format!("There are {count} unused external classes")),
             )
         } else {
             None
@@ -274,7 +274,9 @@ impl Code for CodeC14UnusedExternal {
         }
         let count = self.count.load(std::sync::atomic::Ordering::Relaxed);
         if count > 5 && self.first {
-            Some(String::from("To view them in your terminal, run `hemtt check -Lc14`"))
+            Some(format!(
+                "A list has been generated in {PATH}, use `hemtt check -Lc14` to output warnings",
+            ))
         } else {
             None
         }

--- a/libs/config/src/analyze/lints/collect_cfgfunctions.rs
+++ b/libs/config/src/analyze/lints/collect_cfgfunctions.rs
@@ -47,6 +47,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         _processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Config,
         data: &LintData,
     ) -> Codes {

--- a/libs/config/src/analyze/lints/collect_stringtables.rs
+++ b/libs/config/src/analyze/lints/collect_stringtables.rs
@@ -49,6 +49,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Value,
         data: &LintData,
     ) -> Codes {

--- a/libs/config/src/analyze/mod.rs
+++ b/libs/config/src/analyze/mod.rs
@@ -3,7 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use hemtt_common::config::ProjectConfig;
+use hemtt_common::config::{ProjectConfig, RuntimeArguments};
 use hemtt_workspace::{
     addons::{Addon, DefinedFunctions, MagazineWellInfo},
     lint::LintManager,
@@ -203,16 +203,15 @@ impl Analyze for Item {
 #[must_use]
 #[allow(clippy::ptr_arg)]
 pub fn lint_all(project: Option<&ProjectConfig>, addons: &Vec<Addon>) -> Codes {
-    let default_enabled = project.is_some_and(|p| p.runtime().is_pedantic());
     let mut manager = LintManager::new(
         project.map_or_else(Default::default, |project| project.lints().config().clone()),
+        project.map_or_else(RuntimeArguments::default, |p| p.runtime().clone()),
     );
     let _e = manager.extend(
         crate::analyze::CONFIG_LINTS
             .iter()
             .map(|l| (**l).clone())
             .collect::<Vec<_>>(),
-        default_enabled,
     );
 
     manager.run(

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -19,7 +19,7 @@ pub use model::*;
 
 use analyze::{Analyze, CfgPatch, ChumskyCode, LintData};
 use chumsky::Parser;
-use hemtt_common::version::Version;
+use hemtt_common::{config::RuntimeArguments, version::Version};
 
 use hemtt_common::config::ProjectConfig;
 use hemtt_workspace::{
@@ -52,16 +52,15 @@ pub fn parse(
                 .collect())
         },
         |config| {
-            let default_enabled = project.is_some_and(|p| p.runtime().is_pedantic());
             let mut manager = LintManager::new(
                 project.map_or_else(Default::default, |project| project.lints().config().clone()),
+                project.map_or_else(RuntimeArguments::default, |p| p.runtime().clone()),
             );
             manager.extend(
                 analyze::CONFIG_LINTS
                     .iter()
                     .map(|l| (**l).clone())
                     .collect::<Vec<_>>(),
-                default_enabled,
             )?;
             let localizations = Arc::new(Mutex::new(vec![]));
             let functions_defined = Arc::new(Mutex::new(HashSet::new()));

--- a/libs/sqf/src/analyze/lints/collect_stringtables.rs
+++ b/libs/sqf/src/analyze/lints/collect_stringtables.rs
@@ -47,6 +47,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s01_command_required_version.rs
+++ b/libs/sqf/src/analyze/lints/s01_command_required_version.rs
@@ -63,6 +63,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         _config: &hemtt_common::config::LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Statements,
         data: &LintData,
     ) -> hemtt_workspace::reporting::Codes {

--- a/libs/sqf/src/analyze/lints/s02_event_handlers.rs
+++ b/libs/sqf/src/analyze/lints/s02_event_handlers.rs
@@ -166,6 +166,7 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
         _project: Option<&ProjectConfig>,
         config: std::collections::HashMap<String, LintConfig>,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Statements,
         data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s03_static_typename.rs
+++ b/libs/sqf/src/analyze/lints/s03_static_typename.rs
@@ -60,6 +60,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> hemtt_workspace::reporting::Codes {

--- a/libs/sqf/src/analyze/lints/s04_command_case.rs
+++ b/libs/sqf/src/analyze/lints/s04_command_case.rs
@@ -63,6 +63,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s05_if_assign.rs
+++ b/libs/sqf/src/analyze/lints/s05_if_assign.rs
@@ -64,6 +64,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> hemtt_workspace::reporting::Codes {

--- a/libs/sqf/src/analyze/lints/s06_find_in_str.rs
+++ b/libs/sqf/src/analyze/lints/s06_find_in_str.rs
@@ -56,6 +56,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> hemtt_workspace::reporting::Codes {

--- a/libs/sqf/src/analyze/lints/s07_select_parse_number.rs
+++ b/libs/sqf/src/analyze/lints/s07_select_parse_number.rs
@@ -65,6 +65,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s08_format_args.rs
+++ b/libs/sqf/src/analyze/lints/s08_format_args.rs
@@ -67,6 +67,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s09_banned_command.rs
+++ b/libs/sqf/src/analyze/lints/s09_banned_command.rs
@@ -70,6 +70,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s11_if_not_else.rs
+++ b/libs/sqf/src/analyze/lints/s11_if_not_else.rs
@@ -57,6 +57,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
+++ b/libs/sqf/src/analyze/lints/s17_var_all_caps.rs
@@ -64,6 +64,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s18_in_vehicle_check.rs
+++ b/libs/sqf/src/analyze/lints/s18_in_vehicle_check.rs
@@ -59,6 +59,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s19_extra_not.rs
+++ b/libs/sqf/src/analyze/lints/s19_extra_not.rs
@@ -55,6 +55,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s20_bool_static_comparison.rs
+++ b/libs/sqf/src/analyze/lints/s20_bool_static_comparison.rs
@@ -54,6 +54,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s21_invalid_comparisons.rs
+++ b/libs/sqf/src/analyze/lints/s21_invalid_comparisons.rs
@@ -59,6 +59,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s22_this_call.rs
+++ b/libs/sqf/src/analyze/lints/s22_this_call.rs
@@ -59,6 +59,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s23_reassign_reserved_variable.rs
+++ b/libs/sqf/src/analyze/lints/s23_reassign_reserved_variable.rs
@@ -68,6 +68,7 @@ impl LintRunner<LintData> for StatementsRunner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {
@@ -130,6 +131,7 @@ impl LintRunner<LintData> for ExpressionRunner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s24_marker_spam.rs
+++ b/libs/sqf/src/analyze/lints/s24_marker_spam.rs
@@ -66,6 +66,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s26_short_circuit_bool_var.rs
+++ b/libs/sqf/src/analyze/lints/s26_short_circuit_bool_var.rs
@@ -63,6 +63,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s27_select_count.rs
+++ b/libs/sqf/src/analyze/lints/s27_select_count.rs
@@ -59,6 +59,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s28_banned_macros.rs
+++ b/libs/sqf/src/analyze/lints/s28_banned_macros.rs
@@ -66,6 +66,7 @@ impl LintRunner<LintData> for Runner {
         project: Option<&ProjectConfig>,
         config: &LintConfig,
         processed: Option<&Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/lints/s29_function_undefined.rs
+++ b/libs/sqf/src/analyze/lints/s29_function_undefined.rs
@@ -69,6 +69,7 @@ impl LintRunner<LintData> for RunnerExpression {
         project: Option<&hemtt_common::config::ProjectConfig>,
         _config: &LintConfig,
         processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         data: &LintData,
     ) -> Codes {
@@ -156,6 +157,7 @@ impl LintRunner<LintData> for RunnerStatement {
         project: Option<&hemtt_common::config::ProjectConfig>,
         _config: &LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         data: &LintData,
     ) -> Codes {
@@ -185,6 +187,7 @@ impl LintRunner<LintData> for RunnerFinal {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {

--- a/libs/sqf/src/analyze/mod.rs
+++ b/libs/sqf/src/analyze/mod.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use hemtt_common::config::ProjectConfig;
+use hemtt_common::config::{ProjectConfig, RuntimeArguments};
 use hemtt_workspace::{
     addons::{Addon, DefinedFunctions, UsedFunctions},
     lint::LintManager,
@@ -49,14 +49,13 @@ pub fn analyze(
     addon: Arc<Addon>,
     database: Arc<Database>,
 ) -> (Codes, Option<SqfReport>) {
-    let default_enabled = project.is_some_and(|p| p.runtime().is_pedantic());
     let mut manager: LintManager<LintData> = LintManager::new(
         project.map_or_else(Default::default, |project| project.lints().sqf().clone()),
+        project.map_or_else(RuntimeArguments::default, |p| p.runtime().clone()),
     );
-    if let Err(lint_errors) = manager.extend(
-        SQF_LINTS.iter().map(|l| (**l).clone()).collect::<Vec<_>>(),
-        default_enabled,
-    ) {
+    if let Err(lint_errors) =
+        manager.extend(SQF_LINTS.iter().map(|l| (**l).clone()).collect::<Vec<_>>())
+    {
         return (lint_errors, None);
     }
     if let Err(lint_errors) = manager.push_group(
@@ -66,7 +65,6 @@ pub fn analyze(
             Arc::new(Box::new(LintS02EventInsufficientVersion)),
         ],
         Box::new(EventHandlerRunner),
-        default_enabled,
     ) {
         return (lint_errors, None);
     }
@@ -276,14 +274,11 @@ pub fn lint_all(
     addons: &Vec<Addon>,
     database: Arc<Database>,
 ) -> Codes {
-    let default_enabled = project_config.is_some_and(|p| p.runtime().is_pedantic());
     let mut manager = LintManager::new(
         project_config.map_or_else(Default::default, |project| project.lints().sqf().clone()),
+        project_config.map_or_else(RuntimeArguments::default, |p| p.runtime().clone()),
     );
-    if let Err(e) = manager.extend(
-        SQF_LINTS.iter().map(|l| (**l).clone()).collect::<Vec<_>>(),
-        default_enabled,
-    ) {
+    if let Err(e) = manager.extend(SQF_LINTS.iter().map(|l| (**l).clone()).collect::<Vec<_>>()) {
         return e;
     }
 

--- a/libs/stringtable/src/analyze/lints/l01_sorted.rs
+++ b/libs/stringtable/src/analyze/lints/l01_sorted.rs
@@ -41,6 +41,7 @@ impl LintRunner<LintData> for Runner {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &hemtt_common::config::LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Vec<Project>,
         _data: &LintData,
     ) -> Codes {

--- a/libs/stringtable/src/analyze/lints/l02_usage/mod.rs
+++ b/libs/stringtable/src/analyze/lints/l02_usage/mod.rs
@@ -69,6 +69,7 @@ impl LintRunner<LintData> for Runner {
         project: Option<&hemtt_common::config::ProjectConfig>,
         config: &hemtt_common::config::LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
         target: &Vec<Project>,
         data: &LintData,
     ) -> Codes {

--- a/libs/stringtable/src/analyze/mod.rs
+++ b/libs/stringtable/src/analyze/mod.rs
@@ -1,4 +1,4 @@
-use hemtt_common::config::ProjectConfig;
+use hemtt_common::config::{ProjectConfig, RuntimeArguments};
 use hemtt_workspace::{addons::Addon, lint::LintManager, lint_manager, reporting::Codes};
 
 use crate::Project;
@@ -19,16 +19,17 @@ pub fn lint_one(
     project_config: Option<&ProjectConfig>,
     addons: Vec<Addon>,
 ) -> Codes {
-    let default_enabled = project_config.is_some_and(|p| p.runtime().is_pedantic());
-    let mut manager = LintManager::new(project_config.map_or_else(Default::default, |project| {
-        project.lints().stringtables().clone()
-    }));
+    let mut manager = LintManager::new(
+        project_config.map_or_else(Default::default, |project| {
+            project.lints().stringtables().clone()
+        }),
+        project_config.map_or_else(RuntimeArguments::default, |p| p.runtime().clone()),
+    );
     if let Err(e) = manager.extend(
         STRINGTABLE_LINTS
             .iter()
             .map(|l| (**l).clone())
             .collect::<Vec<_>>(),
-        default_enabled,
     ) {
         return e;
     }
@@ -42,16 +43,17 @@ pub fn lint_all(
     project_config: Option<&ProjectConfig>,
     addons: Vec<Addon>,
 ) -> Codes {
-    let default_enabled = project_config.is_some_and(|p| p.runtime().is_pedantic());
-    let mut manager = LintManager::new(project_config.map_or_else(Default::default, |project| {
-        project.lints().stringtables().clone()
-    }));
+    let mut manager = LintManager::new(
+        project_config.map_or_else(Default::default, |project| {
+            project.lints().stringtables().clone()
+        }),
+        project_config.map_or_else(RuntimeArguments::default, |p| p.runtime().clone()),
+    );
     if let Err(e) = manager.extend(
         STRINGTABLE_LINTS
             .iter()
             .map(|l| (**l).clone())
             .collect::<Vec<_>>(),
-        default_enabled,
     ) {
         return e;
     }

--- a/libs/workspace/src/lint/macros.rs
+++ b/libs/workspace/src/lint/macros.rs
@@ -23,12 +23,12 @@ macro_rules! lint_manager {
             #[must_use]
             pub fn lint_check(
                 config: std::collections::HashMap<String, hemtt_common::config::LintConfigOverride>,
-                default_force_enabled: bool,
+                runtime: hemtt_common::config::RuntimeArguments,
             ) -> $crate::reporting::Codes {
                 let mut manager: $crate::lint::LintManager<super::analyze::LintData> =
-                    $crate::lint::LintManager::new(config);
+                    $crate::lint::LintManager::new(config, runtime);
                 if let Err(lint_errors) =
-                    manager.extend([<$ident:upper _LINTS>].iter().map(|l| (**l).clone()).collect::<Vec<_>>(), default_force_enabled)
+                    manager.extend([<$ident:upper _LINTS>].iter().map(|l| (**l).clone()).collect::<Vec<_>>())
                 {
                     return lint_errors;
                 }
@@ -37,7 +37,7 @@ macro_rules! lint_manager {
                     Box<dyn $crate::lint::AnyLintGroupRunner<super::analyze::LintData>>,
                 )> = $groups;
                 for group in groups {
-                    if let Err(lint_errors) = manager.push_group(group.0, group.1, default_force_enabled) {
+                    if let Err(lint_errors) = manager.push_group(group.0, group.1) {
                         return lint_errors;
                     }
                 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97690ad4-13c7-45b9-b433-b4944516ed0b)

Similar to the unused stringtables

If we go this way instead, do we want to add paths to ignore?

I'm also ok reverting the -Lc14 thing, to be honest I started that, then remembered txt files exist, and did both, but I don't think we *need* it. it changes the lints to pass RuntimeArguments rather than just the bool for pedantic, and those arguments are passed down to the lints, means every lint needs to be modified to add that, but we can reuse that in the future to pass more runtime info down to the lints if needed

Only going to bother with tests if you're ok going this way