### PR TITLE
sqf: S29 - Skip checking undefined functions for `--just` builds

### DIFF
--- a/libs/sqf/src/analyze/lints/s29_function_undefined.rs
+++ b/libs/sqf/src/analyze/lints/s29_function_undefined.rs
@@ -187,11 +187,14 @@ impl LintRunner<LintData> for RunnerFinal {
         _project: Option<&hemtt_common::config::ProjectConfig>,
         config: &LintConfig,
         _processed: Option<&hemtt_workspace::reporting::Processed>,
-        _runtime: &hemtt_common::config::RuntimeArguments,
+        runtime: &hemtt_common::config::RuntimeArguments,
         target: &Self::Target,
         _data: &LintData,
     ) -> Codes {
         let mut codes: Codes = Vec::new();
+        if runtime.is_just() { // --just build will be missing EFUNCS
+            return codes;
+        }
         let mut all_defined = HashSet::new();
         for addon in target {
             let defined = addon


### PR DESCRIPTION
Fix #1029