### PR TITLE
preprocessor: add array support for macro parameters

### DIFF
--- a/libs/preprocessor/src/parse/config.pest
+++ b/libs/preprocessor/src/parse/config.pest
@@ -1,6 +1,7 @@
 file = _{ SOI ~ (
     word | alpha | digit | underscore |
-    left_parentheses | right_parentheses | join |
+    left_parentheses | right_parentheses | 
+    left_brace | right_brace | join |
     directive | escape | comma | double_quote |
     single_quote | left_angle | right_angle |
     equals | unicode | newline
@@ -12,6 +13,8 @@ underscore = { "_" }
 newline = { NEWLINE }
 left_parentheses = { "(" }
 right_parentheses = { ")" }
+left_brace = { "{" }
+right_brace = { "}" }
 directive = { "#" }
 equals = { "=" }
 comma = { "," }

--- a/libs/preprocessor/src/parse/mod.rs
+++ b/libs/preprocessor/src/parse/mod.rs
@@ -180,6 +180,8 @@ impl Parse for Symbol {
             Rule::underscore => Self::Underscore,
             Rule::left_parentheses => Self::LeftParenthesis,
             Rule::right_parentheses => Self::RightParenthesis,
+            Rule::left_brace => Self::LeftBrace,
+            Rule::right_brace => Self::RightBrace,
             Rule::join => Self::Join,
             Rule::directive => Self::Directive,
             Rule::escape => Self::Escape,

--- a/libs/preprocessor/tests/bootstrap.rs
+++ b/libs/preprocessor/tests/bootstrap.rs
@@ -47,6 +47,7 @@ fn check(dir: &str) {
 
 bootstrap!(ace_main);
 bootstrap!(addon_in_ifdef);
+bootstrap!(array_support);
 bootstrap!(cba_is_admin);
 bootstrap!(cba_multiline);
 bootstrap!(comment_edgecase);

--- a/libs/preprocessor/tests/bootstrap/array_support/expected.hpp
+++ b/libs/preprocessor/tests/bootstrap/array_support/expected.hpp
@@ -1,0 +1,3 @@
+
+version = {1,  2,  3};
+class test_mod { version[] =  {3, 15, 7}; };

--- a/libs/preprocessor/tests/bootstrap/array_support/source.hpp
+++ b/libs/preprocessor/tests/bootstrap/array_support/source.hpp
@@ -1,0 +1,5 @@
+#define VERSION_ARRAY(major, minor, patch) {major, minor, patch}
+#define ARRAY_MACRO(name, arr) class name { version[] = arr; };
+
+version = VERSION_ARRAY(1, 2, 3);
+ARRAY_MACRO(test_mod, {3, 15, 7})

--- a/libs/workspace/src/reporting/symbol.rs
+++ b/libs/workspace/src/reporting/symbol.rs
@@ -189,6 +189,18 @@ impl Symbol {
     }
 
     #[must_use]
+    /// Check if a symbol is [`LeftBrace`](Symbol::LeftBrace)
+    pub const fn is_left_brace(&self) -> bool {
+        matches!(self, Self::LeftBrace)
+    }
+
+    #[must_use]
+    /// Check if a symbol is [`RightBrace`](Symbol::RightBrace)
+    pub const fn is_right_brace(&self) -> bool {
+        matches!(self, Self::RightBrace)
+    }
+
+    #[must_use]
     /// Get the opposite symbol of a symbol
     pub const fn matching_enclosure(&self) -> Option<Self> {
         match self {


### PR DESCRIPTION
Arrays containing commas can now be used as macro arguments without being split. The preprocessor now tracks brace depth in addition to parentheses depth when parsing macro arguments, ensuring that commas inside braces are not treated as argument separators.

Changes:
- Add brace parsing to pest grammar and parser
- Track brace depth in call_read_args()
- Add is_left_brace/is_right_brace methods to Symbol
- Update argument splitting logic to respect brace boundaries
- Add comprehensive tests for array macro functionality