### PR TITLE
Photoshoot - Wait until object is ready before taking photos

### DIFF
--- a/bin/dist/profile/autotest/ps_previews.VR/fnc_export.sqf
+++ b/bin/dist/profile/autotest/ps_previews.VR/fnc_export.sqf
@@ -233,6 +233,8 @@ _screenRight = safezoneX + safezoneW;
     _cam camPrepareFocus [-1,-1];
     _cam camPrepareFOV 0.7;
     _cam camCommitPrepared 0;
+    _cam camPreload 0;
+    waitUntil { camPreloaded _cam };
     sleep 0.01;
 
     if (_class isKindOf "man" && !(_class isKindOf "animal")) then {


### PR DESCRIPTION
## Changes
- Preloads the area around the camera so that all necessary textures are fully loaded before any previews are taken