### PR TITLE
sqf: Inspector - Check `params` sub-elements

### DIFF
--- a/hls/src/main.rs
+++ b/hls/src/main.rs
@@ -23,9 +23,9 @@ mod p3d;
 mod paa;
 mod positions;
 mod preprocessor;
+mod rpt;
 mod sqf;
 mod workspace;
-mod rpt;
 
 #[derive(Clone, clap::Args)]
 pub struct Command {

--- a/hls/src/rpt.rs
+++ b/hls/src/rpt.rs
@@ -6,13 +6,15 @@ use crate::Backend;
 impl Backend {
     pub async fn locate_rpt(
         &self,
-        _:  serde_json::Value,
+        _: serde_json::Value,
     ) -> tower_lsp::jsonrpc::Result<Option<serde_json::Value>> {
         info!("Locating Arma 3 installation path via Steam...");
         find_app(107_410)
             .map(|path| {
                 info!("Located Arma 3 installation at {}", path.display());
-                Some(serde_json::Value::String(path.to_string_lossy().to_string()))
+                Some(serde_json::Value::String(
+                    path.to_string_lossy().to_string(),
+                ))
             })
             .ok_or_else(|| {
                 info!("Could not locate Arma 3 installation");

--- a/libs/sqf/src/analyze/inspector/mod.rs
+++ b/libs/sqf/src/analyze/inspector/mod.rs
@@ -284,7 +284,7 @@ impl SciptScope {
                 }
                 let return_set = match cmd {
                     UnaryCommand::Named(named) => match named.to_ascii_lowercase().as_str() {
-                        "params" => Some(self.cmd_generic_params(&rhs_set)),
+                        "params" => Some(self.cmd_generic_params(&rhs_set, &debug_type, source)),
                         "private" => Some(self.cmd_u_private(&rhs_set)),
                         "call" => Some(self.cmd_generic_call(&rhs_set, database)),
                         "isnil" => Some(self.cmd_u_is_nil(&rhs_set, database)),
@@ -358,7 +358,7 @@ impl SciptScope {
                             self.cmd_generic_modify_lvalue(lhs);
                             None
                         }
-                        "params" => Some(self.cmd_generic_params(&rhs_set)),
+                        "params" => Some(self.cmd_generic_params(&rhs_set, &debug_type, source)),
                         "call" => {
                             self.external_function(&lhs_set, rhs, database);
                             Some(self.cmd_generic_call(&rhs_set, database))
@@ -531,7 +531,7 @@ pub fn run_processed(
     scope.eval_statements(statements, database);
     let rv: Vec<Issue> = scope.finish(true, database).into_iter().collect();
     // for ig in ignored_vars.clone() {
-    //     if ig == "_this" {
+    //     if ig == "_this" || ig == "_fnc_scriptname" || ig == "_fnc_scriptnameparent" {
     //         continue;
     //     }
     //     let mut igtest = ignored_vars.clone();

--- a/libs/sqf/tests/inspector/test_variadic.sqf
+++ b/libs/sqf/tests/inspector/test_variadic.sqf
@@ -36,8 +36,10 @@ lineIntersects [eyePos player, aimPos chopper, player, chopper];
 lineIntersects [[eyePos player, aimPos chopper, player, chopper]];
 lineIntersects [[eyePos player, aimPos chopper, player, chopper], [eyePos player, aimPos chopper, player, chopper]];
 
-// param
-// params
+// params is handled in commands.rs
+params ["_var1", objNull];
+params [["_var2", "", ""]];
+params [["_var3", objNull, [false]]];
 
 ppEffectCreate ["ColorCorrections", 1];
 ppEffectCreate [["ColorCorrections", 1]];

--- a/libs/sqf/tests/snapshots/inspector__tests__variadic.snap
+++ b/libs/sqf/tests/snapshots/inspector__tests__variadic.snap
@@ -2,4 +2,4 @@
 source: libs/sqf/tests/inspector.rs
 expression: "(issues.len(), issues)"
 ---
-(1, [InvalidArgs("[U:createHashMapFromArray]", 684..706)])
+(7, [InvalidArgs("[U:createHashMapFromArray]", 684..706), InvalidArgs("[U:params] - 1: Element Type", 1050..1056), InvalidArgs("[U:params] - 0: Expected Data Types", 1077..1083), InvalidArgs("[U:params] - 0: Default Value does not match declared types", 1105..1111), Unused("_var1", Params(1058..1065)), Unused("_var2", Params(1086..1093)), Unused("_var3", Params(1114..1121))])


### PR DESCRIPTION
Close #1081

```
help[L-S12]: Invalid arguments to command `[U:params] - 1: Element Type`
  ┌─ addons/main/test.sqf:1:1
  │
1 │ params ["_var1", objNull];
  │ ^^^^^^ invalid arguments


help[L-S12]: Invalid arguments to command `[U:params] - 0: Expected Data Types`
  ┌─ addons/main/test.sqf:2:1
  │
2 │ params [["_var2", "", ""]];
  │ ^^^^^^ invalid arguments


help[L-S12]: Invalid arguments to command `[U:params] - 0: Default Value does not match declared types`
  ┌─ addons/main/test.sqf:3:1
  │
3 │ params [["_var3", objNull, [false]]];
  │ ^^^^^^ invalid arguments
```

CBA has one example of the last type
https://github.com/CBATeam/CBA_A3/blob/master/addons/common/fnc_registerFeatureCamera.sqf#L28
but I don't see any good reason to write it like that, so I think it's a safe thing to check
