### PR TITLE
Build hemtt without lsp feature (enable caching)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           key: build-${{ matrix.os.name }}
       - name: Compile
-        run: cargo build --release --bin hemtt
+        run: cargo build --release --bin hemtt -p hemtt
       - name: Upload
         uses: actions/upload-artifact@v5
         with:


### PR DESCRIPTION
Disable the `"lsp"` feature when just building the hemtt binary
This will re-enable token caching,
ace `check`s about 3 times faster on my machine.
I'm not sure if something changed in how rust does features? 
but it seems like the hls package is always active without the extra `-p`

<img width="688" height="364" alt="image" src="https://github.com/user-attachments/assets/e11a69c4-7b87-4e55-868b-db67124a8b2d" />
