### PR TITLE
hls - fix path on windows

### DIFF
--- a/hls/src/workspace.rs
+++ b/hls/src/workspace.rs
@@ -13,7 +13,7 @@ use tower_lsp::{
 use tracing::debug;
 use url::Url;
 
-use crate::{config::ConfigAnalyzer, sqf::SqfAnalyzer};
+use crate::{config::ConfigAnalyzer, sqf::SqfAnalyzer, workspace};
 
 #[derive(Clone)]
 pub struct EditorWorkspaces {
@@ -152,7 +152,8 @@ impl EditorWorkspace {
 
     pub fn join_url(&self, url: &Url) -> Result<WorkspacePath, String> {
         let decoded_path = urlencoding::decode(url.path()).map_err(|e| format!("{e}"))?;
-        let Some(path) = decoded_path.strip_prefix(self.url.path()) else {
+        let workspace_path = urlencoding::decode(self.url.path()).map_err(|e| format!("{e}"))?;
+        let Some(path) = decoded_path.strip_prefix(workspace_path.as_ref()) else {
             return Err("URL is not in workspace".to_string());
         };
         self.workspace.join(path).map_err(|e| format!("{e}"))


### PR DESCRIPTION
ref https://discord.com/channels/976165959041679380/1039189045655392389/1438929439298945094
fixes
```
2025-11-14T17:22:54.376050Z  INFO hemtt_language_server: initialized
2025-11-14T17:22:54.376089Z  WARN hemtt_language_server::config::lints: failed to join url Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/f%3A/DEV/POTATO/addons/missionMaking/functions/fnc_copyMapName.sqf", query: None, fragment: None }
2025-11-14T17:22:54.376131Z  WARN hemtt_language_server::sqf::lints: Failed to join URL Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/f%3A/DEV/POTATO/addons/missionMaking/functions/fnc_copyMapName.sqf", query: None, fragment: None } in workspace Url { scheme: "file", cannot_be_a_base: false, username: "", password: None, host: None, port: None, path: "/f%3A/DEV/POTATO", query: None, fragment: None }
```

I assume this was only a problem on windows, so I'm not sure how this fix effects unix
roughly it seems like the decode changes path from
`f%3A/DEV/` to `f:/DEV`
so doing the same decoding on both paths, makes the `strip_prefix` work again