### PR TITLE
add support for CfgSoundShaders samples for c11_file_type lint

### DIFF
--- a/libs/config/src/analyze/lints/c11_file_type.rs
+++ b/libs/config/src/analyze/lints/c11_file_type.rs
@@ -204,7 +204,7 @@ fn allowed_ext(name: &str) -> Vec<&str> {
     if name.ends_with("opticsmodel") {
         return vec!["p3d"];
     }
-    if name.contains("sound") && !name.contains("soundset") {
+    if name.contains("sound") && !name.contains("soundset") || name.eq("samples") {
         return vec!["wss", "ogg", "wav"];
     }
     if name.starts_with("scud") {


### PR DESCRIPTION
Sound Files in CfgSoundShaders are stored in a value called samples they support the same wss, wav and ogg file types
example:
```cpp
class CfgSoundShaders {
	class test_sound_shader {
		samples[]=
		{
			{"PATHTO_FILE1",1},
			{"PATHTO_FILE2",1},
			{"PATHTO_FILE3",1}
		};
		volume="1*interior";
		range=100;
		rangeCurve[] = {{0,1},{25,0.75},{75,0.5},{100,0}};
	};
};

```