### PR TITLE
book: fix Arma typo

### DIFF
--- a/book/installation/arma3tools.md
+++ b/book/installation/arma3tools.md
@@ -1,6 +1,6 @@
 # Arma 3 Tools
 
-HEMTT will use your installation of Arm 3 Tools to binarize supported files (p3d, rtm, wrp).
+HEMTT will use your installation of Arma 3 Tools to binarize supported files (p3d, rtm, wrp).
 
 ## Installation
 


### PR DESCRIPTION
I was very tempted to put ArmA (or aRMa).
Marvel at my restraint.