### PR TITLE
sqf: Fix inspector warns for wiki types, handle `addPublicVariableEH`

### DIFF
--- a/libs/sqf/src/analyze/inspector/game_value.rs
+++ b/libs/sqf/src/analyze/inspector/game_value.rs
@@ -341,6 +341,7 @@ impl GameValue {
                 IndexSet::from([Self::Anything])
             }
             _ => {
+                #[cfg(debug_assertions)]
                 warn!("wiki type [{value:?}] not matched");
                 IndexSet::from([Self::Anything])
             }

--- a/libs/sqf/src/analyze/inspector/mod.rs
+++ b/libs/sqf/src/analyze/inspector/mod.rs
@@ -551,7 +551,7 @@ impl Inspector {
                             self.external_function(&lhs_set, rhs, database);
                             Some(self.cmd_generic_call(&rhs_set, None, database))
                         }
-                        "spawn" => {
+                        "spawn" | "addpublicvariableeventhandler" => {
                             self.external_new_scope(
                                 &rhs_set.into_iter().map(|gv| (gv, source.clone())).collect(),
                                 &vec![],

--- a/libs/sqf/tests/inspector.rs
+++ b/libs/sqf/tests/inspector.rs
@@ -75,6 +75,9 @@ mod tests {
                 "isnull",             // example - creatediaryrecord null
                 "buttonaction",       // example
                 "privateall",         // example
+                "setturretlimits",    // syntax2 (fixed)
+                "breakwith",          // example
+                "cutrsc",             // example3 (fixed)
             ]
             .contains(&cmd.name().to_ascii_lowercase().as_str())
             {

--- a/libs/sqf/tests/inspector/test_code_usage.sqf
+++ b/libs/sqf/tests/inspector/test_code_usage.sqf
@@ -8,4 +8,7 @@ try {
     hint str _exception;
 };
 
+private _testHandler = { YYY = _testVariable };
+"XXX" addPublicVariableEventHandler _testHandler; // called in event scope, so _testVariable is undef
+
 // ToDo 2.22 spawn/continueWith

--- a/libs/sqf/tests/snapshots/inspector__tests__code_usage.snap
+++ b/libs/sqf/tests/snapshots/inspector__tests__code_usage.snap
@@ -2,4 +2,4 @@
 source: libs/sqf/tests/inspector.rs
 expression: "(issues.len(), issues)"
 ---
-(2, [InvalidArgs { command: "[B:/]", span: 208..209, variant: TypeNotExpected { expected: [Number(None), Config], found: [String(Some(String("a", 175..178, DoubleQuote)))], span: 194..207 } }, InvalidArgs { command: "[B:/]", span: 208..209, variant: TypeNotExpected { expected: [Number(None), String(None)], found: [Number(Some(Number(FloatOrd(2.0), 210..211)))], span: 210..211 } }])
+(3, [InvalidArgs { command: "[B:/]", span: 208..209, variant: TypeNotExpected { expected: [Number(None), Config], found: [String(Some(String("a", 175..178, DoubleQuote)))], span: 194..207 } }, InvalidArgs { command: "[B:/]", span: 208..209, variant: TypeNotExpected { expected: [Number(None), String(None)], found: [Number(Some(Number(FloatOrd(2.0), 210..211)))], span: 210..211 } }, Undefined("_testVariable", 320..333, false)])


### PR DESCRIPTION
Quick fix for
`WARN wiki type [Vector3d] not matched`
(minimizing merge conflicts)

Handle addPubVarEH (syntax1, 2 is "broken")
ref https://github.com/acemod/ACE3/pull/11254
