### PR TITLE
preprocessor: Use quoted strings for `__FILE_NAME__` macros

### DIFF
--- a/libs/preprocessor/src/defines.rs
+++ b/libs/preprocessor/src/defines.rs
@@ -205,10 +205,11 @@ impl Defines {
                         let path = site.path().filename();
                         return Some((
                             key.clone(),
-                            Definition::Value(Arc::new(vec![Arc::new(Token::new(
-                                Symbol::Word(path),
-                                key.position().clone(),
-                            ))])),
+                            Definition::Value(Arc::new(vec![
+                                Arc::new(Token::new(Symbol::DoubleQuote, key.position().clone())),
+                                Arc::new(Token::new(Symbol::Word(path), key.position().clone())),
+                                Arc::new(Token::new(Symbol::DoubleQuote, key.position().clone())),
+                            ])),
                             DefineSource::Generated,
                         ));
                     }
@@ -226,10 +227,11 @@ impl Defines {
                             .collect::<String>();
                         return Some((
                             key.clone(),
-                            Definition::Value(Arc::new(vec![Arc::new(Token::new(
-                                Symbol::Word(path),
-                                key.position().clone(),
-                            ))])),
+                            Definition::Value(Arc::new(vec![
+                                Arc::new(Token::new(Symbol::DoubleQuote, key.position().clone())),
+                                Arc::new(Token::new(Symbol::Word(path), key.position().clone())),
+                                Arc::new(Token::new(Symbol::DoubleQuote, key.position().clone())),
+                            ])),
                             DefineSource::Generated,
                         ));
                     }


### PR DESCRIPTION
Ref #1193
This fixes `__FILE_NAME__` and `__FILE_SHORT__` to match the arma preprocesssor
Possibly a breaking change if people have code that added quotes to handle old behaviour!

```
input:
a = __FILE_NAME__;
b = __FILE_SHORT__;
c = __LINE__;
d = __FILE__;
e = __COUNTER__;

hemtt:
a = "config.cpp";
b = "config";
c = 22;
d = "x\cba\addons\accessory\config.cpp";
e = 0;

native:
a = "config.cpp";
b = "config";
c = 21;
d = "x\cba\addons\accessory\config.cpp";
e = 0;

hls:
a = "config.cpp";
b = "config";
c = 22;
d = "\addons\accessory\config.cpp";
e = 0;
```


HLS has problems with `__FILE__` but that seems to be because it's not finding the project
hitting line 169 `Arc::new(site.path().workspace().project().map_or_else(`
and seems unrelated

