### PR TITLE
sqf: S38-S44, new lints

### DIFF
--- a/libs/sqf/src/analyze/lints/s02_event_handlers.rs
+++ b/libs/sqf/src/analyze/lints/s02_event_handlers.rs
@@ -174,33 +174,31 @@ impl LintGroupRunner<LintData> for EventHandlerRunner {
             return Vec::new();
         };
         let mut codes: Codes = Vec::new();
-        for statement in target.content() {
-            for expression in statement.walk_expressions() {
-                let Some((ns, name, id, target)) = get_namespaces(expression) else {
-                    continue;
-                };
-                if ns.is_empty() {
-                    continue;
-                }
-                if name.contains("UserAction") {
-                    // Requires arma3-wiki to parse and provide https://community.bistudio.com/wiki/inputAction/actions
-                    continue;
-                }
-                let eh = data.database.wiki().event_handler(&id.0);
-                codes.extend(check_unknown(
-                    &ns,
-                    &name,
-                    &id,
-                    target.map(|t| &**t),
-                    &eh,
-                    processed,
-                    &data.database,
-                    config.get("event_unknown"),
-                ));
-                codes.extend(check_version(
-                    data.addon.as_ref().expect("addon will exist"), &ns, &name, &id, &eh, processed, &data.database,
-                ));
+        for expression in target.walk_expressions() {
+            let Some((ns, name, id, target)) = get_namespaces(expression) else {
+                continue;
+            };
+            if ns.is_empty() {
+                continue;
             }
+            if name.contains("UserAction") {
+                // Requires arma3-wiki to parse and provide https://community.bistudio.com/wiki/inputAction/actions
+                continue;
+            }
+            let eh = data.database.wiki().event_handler(&id.0);
+            codes.extend(check_unknown(
+                &ns,
+                &name,
+                &id,
+                target.map(|t| &**t),
+                &eh,
+                processed,
+                &data.database,
+                config.get("event_unknown"),
+            ));
+            codes.extend(check_version(
+                data.addon.as_ref().expect("addon will exist"), &ns, &name, &id, &eh, processed, &data.database,
+            ));
         }
         codes
     }

--- a/libs/sqf/src/analyze/lints/s36_global_var_in_local.rs
+++ b/libs/sqf/src/analyze/lints/s36_global_var_in_local.rs
@@ -100,7 +100,6 @@ impl LintRunner<LintData> for Runner {
                 }
             }
             Statement::AssignLocal(var, _, span) if !(var.is_empty() || var.starts_with('_')) => {
-                 
                     let haystack = processed.extract(span);
                     let start = span.start + haystack.find(var).unwrap_or(0);
                     return vec![Arc::new(Code36GlobalVarInLocal::new(

--- a/libs/sqf/src/analyze/lints/s38_direct_private.rs
+++ b/libs/sqf/src/analyze/lints/s38_direct_private.rs
@@ -1,0 +1,201 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Label, Processed, Severity},
+    WorkspacePath,
+};
+
+use crate::{
+    Expression, Statement, UnaryCommand,
+    analyze::LintData,
+};
+
+crate::analyze::lint!(LintS38DirectPrivate);
+
+impl Lint<LintData> for LintS38DirectPrivate {
+    fn ident(&self) -> &'static str {
+        "direct_private"
+    }
+
+    fn sort(&self) -> u32 {
+        380
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for private declarations that are followed by a separate assignment"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Example
+
+**Incorrect**
+```sqf
+private ["_a"];
+_a = 1;
+```
+
+**Correct**
+```sqf
+private _a = 1;
+```
+
+### Explanation
+
+Declaring a private variable and assigning it in a separate statement is slower than using a direct initializer. The direct form avoids an extra initialization step.
+"#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Statements;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        let mut pending: Vec<(String, Range<usize>)> = Vec::new();
+        let mut codes: Codes = Vec::new();
+
+        for statement in target.content() {
+            match statement {
+                Statement::Expression(Expression::UnaryCommand(UnaryCommand::Named(cname), rhs, _), _) if cname.eq_ignore_ascii_case("private") => {
+                    pending.extend(collect_declared_variables(rhs));
+                }
+                Statement::AssignGlobal(var, _, assignment_span)
+                | Statement::AssignLocal(var, _, assignment_span) => {
+                    if let Some((declared_var, declaration_span)) = pending.iter().find_map(|(name, span)| (name == var).then_some((name.clone(), span.clone()))) {
+                        codes.push(Arc::new(CodeS38DirectPrivate::new(
+                            declared_var,
+                            declaration_span,
+                            assignment_span.clone(),
+                            processed,
+                            config.severity(),
+                        )));
+                        pending.retain(|(name, _)| name != var);
+                    }
+                }
+                Statement::Expression(_, _) => {},
+            }
+        }
+
+        codes
+    }
+}
+
+fn collect_declared_variables(expression: &Expression) -> Vec<(String, Range<usize>)> {
+    match expression {
+        Expression::String(name, span, _) if !name.is_empty() => vec![(name.to_string(), span.clone())],
+        Expression::Array(values, _) => values
+            .iter()
+            .filter_map(|value| match value {
+                Expression::String(name, span, _) if !name.is_empty() => Some((name.to_string(), span.clone())),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS38DirectPrivate {
+    variable: String,
+    declaration_span: Range<usize>,
+    assignment_span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS38DirectPrivate {
+    fn ident(&self) -> &'static str {
+        "L-S38"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#direct_private")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        format!("Use `private {} = <value>` instead of declaring then assigning", self.variable)
+    }
+
+    fn label_message(&self) -> String {
+        "declaration followed by assignment".to_string()
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("private {} = <value>", self.variable))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS38DirectPrivate {
+    #[must_use]
+    pub fn new(
+        variable: String,
+        declaration_span: Range<usize>,
+        assignment_span: Range<usize>,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            variable,
+            declaration_span,
+            assignment_span,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        let Some(mut diag) = Diagnostic::from_code_processed(&self, self.assignment_span.clone(), processed) else {
+            return self;
+        };
+        diag = diag.clear_labels();
+        if let Some((file, span)) = get_span_info(self.declaration_span.clone(), processed) {
+            diag = diag.with_label(Label::secondary(file, span).with_message("declaration"));
+        }
+        if let Some((file, span)) = get_span_info(self.assignment_span.clone(), processed) {
+            diag = diag.with_label(Label::primary(file, span).with_message("assignment"));
+        }
+        self.diagnostic = Some(diag);
+        self
+    }
+}
+
+fn get_span_info(span: Range<usize>, processed: &Processed) -> Option<(WorkspacePath, Range<usize>)> {
+    let map_start = processed.mapping(span.start)?;
+    let map_end = processed.mapping(span.end)?;
+    let map_file = processed.source(map_start.source())?;
+    Some((
+        map_file.0.clone(),
+        map_start.original_start()..map_end.original_start(),
+    ))
+}

--- a/libs/sqf/src/analyze/lints/s39_replaced_functions.rs
+++ b/libs/sqf/src/analyze/lints/s39_replaced_functions.rs
@@ -1,0 +1,213 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{analyze::LintData, BinaryCommand, Expression};
+
+crate::analyze::lint!(LintS39ReplacedFunctions);
+
+impl Lint<LintData> for LintS39ReplacedFunctions {
+    fn ident(&self) -> &'static str {
+        "replaced_functions"
+    }
+
+    fn sort(&self) -> u32 {
+        390
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for usage of BIS functions that have been replaced by commands. The lint will skip any files starting with `_bi_` or `bis` as these are considered modified internal Arma files."
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+[a,b,c] call BIS_fnc_selectRandom;
+```
+**Correct**
+```sqf
+selectRandom [a,b,c];
+```
+
+### Explanation
+
+Some BIS functions have been replaced by commands, which are more efficient and easier to read. Using the native commands is recommended for better performance.
+"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::warning()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+pub enum ReplacedShaped {
+    Unary,
+    Binary,
+}
+
+const REPLACED_FUNCTIONS: &[(&str, &str, ReplacedShaped)] = &[
+    ("BIS_fnc_selectRandom", "selectRandom", ReplacedShaped::Unary),
+    ("BIS_fnc_selectRandomWeighted", "selectRandomWeighted", ReplacedShaped::Unary),
+    ("BIS_fnc_areEqual", "isEqualTo", ReplacedShaped::Binary),
+    ("BIS_fnc_vectorMultiply", "vectorMultiply", ReplacedShaped::Binary),
+    ("BIS_fnc_vectorDivide", "vectorDivide", ReplacedShaped::Binary),
+    ("BIS_fnc_vectorAdd", "vectorAdd", ReplacedShaped::Binary),
+    ("BIS_fnc_vectorSubtract", "vectorSubtract", ReplacedShaped::Binary),
+    ("BIS_fnc_vectorDiff", "vectorDiff", ReplacedShaped::Binary),
+    ("BIS_fnc_linearConversion", "linearConversion", ReplacedShaped::Unary),
+    ("BIS_fnc_param", "param", ReplacedShaped::Unary),
+    ("BIS_fnc_MP", "remoteExec", ReplacedShaped::Unary),
+];
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        let Some(mapping) = processed.mapping(target.span().start) else {
+            return Vec::new();
+        };
+        let Some((source, _)) = processed.source(mapping.source()) else {
+            return Vec::new();
+        };
+        if source.as_str().contains("_bi_") || source.as_str().contains("bis") {
+            return Vec::new();
+        }
+
+        let Expression::BinaryCommand(BinaryCommand::Named(cmd), lhs, rhs, _) = target else {
+            return Vec::new();
+        };
+        
+        if !cmd.eq_ignore_ascii_case("call") {
+            return Vec::new();
+        }
+
+        let Expression::Variable(function_name, _) = &**rhs else {
+            return Vec::new();
+        };
+
+        let Some((_, replacement, shape)) = REPLACED_FUNCTIONS.iter().find(|(name, _, _)| name.eq_ignore_ascii_case(function_name)) else {
+            return Vec::new();
+        };
+
+        let replacement_cmd = match shape {
+            ReplacedShaped::Unary => Expression::UnaryCommand(
+                crate::UnaryCommand::Named(replacement.to_string()),
+                lhs.clone(),
+                lhs.span(),
+            ),
+            ReplacedShaped::Binary => {
+                let Expression::Array(parts, _) = &**lhs else {
+                    return Vec::new();
+                };
+                if parts.len() != 2 {
+                    return Vec::new();
+                }
+                let lhs = Box::new(parts[0].clone());
+                let lhs_span = lhs.span();
+                let rhs = Box::new(parts[1].clone());
+                Expression::BinaryCommand(
+                    crate::BinaryCommand::Named(replacement.to_string()),
+                    lhs,
+                    rhs,
+                    lhs_span,
+                )
+            },
+        };
+
+        vec![Arc::new(CodeS39ReplacedFunctions::new(
+            target.full_span(),
+            processed,
+            config.severity(),
+            replacement_cmd.source(false),
+            replacement.to_string(),
+        ))]
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS39ReplacedFunctions {
+    span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+    replacement: String,
+    replacement_cmd: String,
+}
+
+impl Code for CodeS39ReplacedFunctions {
+    fn ident(&self) -> &'static str {
+        "L-S39"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#replaced_functions")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "Function has been replaced by command: `{}`",
+            self.replacement_cmd
+        )
+    }
+
+    fn label_message(&self) -> String {
+        format!("use `{}`", self.replacement_cmd)
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        if self.replacement_cmd == "remoteExec" || self.replacement_cmd == "param" {
+            None
+        } else {
+            Some(self.replacement.clone())
+        }
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS39ReplacedFunctions {
+    #[must_use]
+    pub fn new(span: Range<usize>, processed: &Processed, severity: Severity, replacement: String, replacement_cmd: String) -> Self {
+        Self {
+            span,
+            severity,
+            diagnostic: None,
+            replacement,
+            replacement_cmd,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s40_string_concat_in_loop.rs
+++ b/libs/sqf/src/analyze/lints/s40_string_concat_in_loop.rs
@@ -1,0 +1,466 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Label, Processed, Severity},
+    WorkspacePath,
+};
+
+use crate::{
+    BinaryCommand, Expression, Statement, Statements, UnaryCommand,
+    analyze::LintData,
+};
+
+crate::analyze::lint!(LintS40StringConcatInLoop);
+
+impl Lint<LintData> for LintS40StringConcatInLoop {
+    fn ident(&self) -> &'static str {
+        "string_concat_in_loop"
+    }
+
+    fn sort(&self) -> u32 {
+        400
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for repeated string concatenation inside loops"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Example
+
+**Incorrect**
+```sqf
+private _myString = "";
+for [{_i = 0}, {_i < 10000}, {_i = _i + 1}] do {
+    _myString = _myString + "123";
+};
+```
+
+**Correct**
+```sqf
+private _strings = [];
+for [{_i = 0}, {_i < 10000}, {_i = _i + 1}] do {
+    _strings pushBack "123";
+};
+private _myString = _strings joinString "";
+```
+
+### Explanation
+
+Repeatedly concatenating a string inside a loop can become very slow for large iteration counts. Building an array of fragments and joining them once at the end is typically much faster.
+"#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help().with_options(
+            std::iter::once((
+                "threshold".to_string(),
+                toml::Value::Integer(1000),
+            ))
+            .collect(),
+        )
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Statements;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        let threshold = config
+            .option("threshold")
+            .and_then(toml::Value::as_integer)
+            .unwrap_or(1000);
+
+        let mut codes: Codes = Vec::new();
+        for (index, statement) in target.content().iter().enumerate() {
+            let Some((loop_count, body)) = extract_loop_body(statement) else {
+                continue;
+            };
+            if loop_count <= threshold {
+                continue;
+            }
+
+            let Some((concat_var, concat_span)) = find_string_concat_assignment(body) else {
+                continue;
+            };
+            if !is_string_accumulator(target.content(), index, &concat_var) {
+                continue;
+            }
+            let Some(declaration_span) = find_variable_declaration_span(target.content(), index, &concat_var) else {
+                continue;
+            };
+
+            codes.push(Arc::new(CodeS40StringConcatInLoop::new(
+                Some(declaration_span),
+                concat_span,
+                processed,
+                config.severity(),
+            )));
+        }
+
+        codes
+    }
+}
+
+fn extract_loop_body(statement: &Statement) -> Option<(i64, &Statements)> {
+    let Statement::Expression(expression, _) = statement else {
+        return None;
+    };
+
+    match expression {
+        Expression::BinaryCommand(BinaryCommand::Named(cmd), lhs, rhs, _) if cmd.eq_ignore_ascii_case("do") => {
+            let loop_count = match lhs.as_ref() {
+                Expression::UnaryCommand(UnaryCommand::Named(name), _, _) if name.eq_ignore_ascii_case("for") => {
+                    parse_for_loop_iterations(lhs.as_ref())
+                }
+                Expression::UnaryCommand(UnaryCommand::Named(name), loop_args, _) if name.eq_ignore_ascii_case("foreach") => {
+                    #[allow(clippy::cast_possible_wrap)]
+                    let loop_count = match loop_args.as_ref() {
+                        Expression::Array(values, _) | Expression::ConsumeableArray(values, _) => Some(values.len() as i64),
+                        _ => None,
+                    }?;
+                    Some(loop_count)
+                }
+                _ => parse_for_loop_iterations(lhs.as_ref()),
+            }?;
+
+            let Expression::Code(body) = rhs.as_ref() else { return None };
+
+            Some((loop_count, body))
+        }
+        Expression::BinaryCommand(BinaryCommand::Named(cmd), lhs, rhs, _) if cmd.eq_ignore_ascii_case("foreach") || cmd.eq_ignore_ascii_case("forEach") => {
+            let Expression::Code(body) = lhs.as_ref() else { return None };
+            #[allow(clippy::cast_possible_wrap)]
+            let loop_count = match rhs.as_ref() {
+                Expression::Array(values, _) | Expression::ConsumeableArray(values, _) => values.len() as i64,
+                _ => i64::MAX,
+            };
+            Some((loop_count, body))
+        }
+        _ => None,
+    }
+}
+
+fn find_variable_declaration_span(statements: &[Statement], current_index: usize, variable: &str) -> Option<Range<usize>> {
+    for statement in statements.iter().take(current_index).rev() {
+        match statement {
+            Statement::AssignGlobal(name, _, span) | Statement::AssignLocal(name, _, span) => {
+                if name == variable {
+                    return Some(span.clone());
+                }
+            }
+            Statement::Expression(Expression::UnaryCommand(UnaryCommand::Named(command), rhs, _), _) if command.eq_ignore_ascii_case("private") => {
+                if let Some((declared_var, span)) = collect_declared_variables(rhs).into_iter().find(|(declared_var, _)| declared_var == variable) {
+                    let _ = declared_var;
+                    return Some(span);
+                }
+            }
+            Statement::Expression(_, _) => {},
+        }
+    }
+    None
+}
+
+fn collect_declared_variables(expression: &Expression) -> Vec<(String, Range<usize>)> {
+    match expression {
+        Expression::String(name, span, _) if !name.is_empty() => vec![(name.to_string(), span.clone())],
+        Expression::Array(values, _) => values
+            .iter()
+            .filter_map(|value| match value {
+                Expression::String(name, span, _) if !name.is_empty() => Some((name.to_string(), span.clone())),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_for_loop_iterations(expression: &Expression) -> Option<i64> {
+    match expression {
+        Expression::UnaryCommand(UnaryCommand::Named(name), loop_args, _) if name.eq_ignore_ascii_case("for") => {
+            if let Some(iterations) = parse_bracket_loop_iterations(loop_args.as_ref()) {
+                return Some(iterations);
+            }
+
+            parse_from_to_loop_iterations(loop_args.as_ref())
+        }
+        Expression::BinaryCommand(BinaryCommand::Named(command), lhs, rhs, _) if command.eq_ignore_ascii_case("to") => {
+            parse_from_to_loop_iterations(expression)
+        }
+        Expression::BinaryCommand(BinaryCommand::Named(command), lhs, rhs, _) if command.eq_ignore_ascii_case("from") => {
+            parse_from_to_loop_iterations(expression)
+        }
+        _ => None,
+    }
+}
+
+fn parse_bracket_loop_iterations(expression: &Expression) -> Option<i64> {
+    let Expression::Array(parts, _) = expression else {
+        return None;
+    };
+    if parts.len() != 3 {
+        return None;
+    }
+
+    let Some(Expression::Code(Statements { content, .. })) = parts.first() else {
+        return None;
+    };
+    let Some(Statement::AssignGlobal(_, init, _) | Statement::AssignLocal(_, init, _)) = content.first() else {
+        return None;
+    };
+    #[allow(clippy::cast_possible_truncation)]
+    let init_value = match init {
+        Expression::Number(n, _) => n.0 as i64,
+        _ => return None,
+    };
+
+    let Some(Expression::Code(Statements { content, .. })) = parts.get(1) else {
+        return None;
+    };
+    let Some(Statement::Expression(Expression::BinaryCommand(command, lhs, rhs, _), _)) = content.first() else {
+        return None;
+    };
+    #[allow(clippy::cast_possible_truncation)]
+    let limit = match command {
+        BinaryCommand::Less | BinaryCommand::LessEq => match rhs.as_ref() {
+            Expression::Number(n, _) => n.0 as i64,
+            _ => return None,
+        },
+        BinaryCommand::Greater | BinaryCommand::GreaterEq => match lhs.as_ref() {
+            Expression::Number(n, _) => n.0 as i64,
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    let Some(Expression::Code(Statements { content, .. })) = parts.get(2) else {
+        return None;
+    };
+    let Some(Statement::AssignGlobal(_, increment, _) | Statement::AssignLocal(_, increment, _)) = content.first() else {
+        return None;
+    };
+    #[allow(clippy::cast_possible_truncation)]
+    let step = match increment {
+        Expression::BinaryCommand(BinaryCommand::Add, _, rhs, _) => match rhs.as_ref() {
+            Expression::Number(n, _) => n.0 as i64,
+            _ => return None,
+        },
+        Expression::BinaryCommand(BinaryCommand::Sub, _, rhs, _) => match rhs.as_ref() {
+            Expression::Number(n, _) => -(n.0 as i64),
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    let span = limit - init_value;
+    if span <= 0 {
+        return Some(0);
+    }
+    Some(span / step)
+}
+
+fn parse_from_to_loop_iterations(expression: &Expression) -> Option<i64> {
+    let Expression::BinaryCommand(BinaryCommand::Named(command), lhs, rhs, _) = expression else {
+        return None;
+    };
+    if !command.eq_ignore_ascii_case("to") {
+        return None;
+    }
+
+    let start_value = parse_from_expression(lhs.as_ref())?;
+    #[allow(clippy::cast_possible_truncation)]
+    let limit_value = match rhs.as_ref() {
+        Expression::Number(n, _) => n.0 as i64,
+        _ => return None,
+    };
+
+    let span = limit_value - start_value;
+    if span <= 0 {
+        return Some(0);
+    }
+    Some(span)
+}
+
+fn parse_from_expression(expression: &Expression) -> Option<i64> {
+    let Expression::BinaryCommand(BinaryCommand::Named(command), lhs, rhs, _) = expression else {
+        return None;
+    };
+    if !command.eq_ignore_ascii_case("from") {
+        return None;
+    }
+
+    let _ = lhs.as_ref();
+    #[allow(clippy::cast_possible_truncation)]
+    match rhs.as_ref() {
+        Expression::Number(n, _) => Some(n.0 as i64),
+        _ => None,
+    }
+}
+
+fn find_string_concat_assignment(statements: &Statements) -> Option<(String, Range<usize>)> {
+    statements.content().iter().find_map(|statement| match statement {
+        Statement::AssignGlobal(var, expr, span) | Statement::AssignLocal(var, expr, span) => {
+            is_string_concat_assignment(var, expr).then(|| (var.clone(), span.clone()))
+        }
+        Statement::Expression(_, _) => None,
+    })
+}
+
+fn is_string_accumulator(statements: &[Statement], current_index: usize, variable: &str) -> bool {
+    for statement in statements.iter().take(current_index).rev() {
+        match statement {
+            Statement::AssignGlobal(name, expr, _) | Statement::AssignLocal(name, expr, _) if name == variable => {
+                return is_string_initializer(expr);
+            }
+            Statement::Expression(Expression::UnaryCommand(UnaryCommand::Named(command), rhs, _), _) if command.eq_ignore_ascii_case("private")
+                && collect_declared_variables(rhs)
+                    .into_iter()
+                    .any(|(declared_var, _)| declared_var == variable)
+                => {
+                    return false;
+                }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn is_string_initializer(expression: &Expression) -> bool {
+    match expression {
+        Expression::String(_, _, _) => true,
+        Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) => {
+            is_string_initializer(lhs.as_ref()) || is_string_initializer(rhs.as_ref())
+        }
+        _ => false,
+    }
+}
+
+fn is_string_concat_assignment(variable: &str, expression: &Expression) -> bool {
+    let Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) = expression else {
+        return false;
+    };
+    let lhs_is_variable = matches!(lhs.as_ref(), Expression::Variable(name, _) if name == variable);
+    let rhs_is_variable = matches!(rhs.as_ref(), Expression::Variable(name, _) if name == variable);
+    if !lhs_is_variable && !rhs_is_variable {
+        return false;
+    }
+    is_string_like(lhs.as_ref()) || is_string_like(rhs.as_ref())
+}
+
+fn is_string_like(expression: &Expression) -> bool {
+    match expression {
+        Expression::String(_, _, _) | Expression::Variable(_, _) => true,
+        Expression::UnaryCommand(UnaryCommand::Named(name), _, _) => {
+            name.eq_ignore_ascii_case("format")
+        }
+        Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) => {
+            is_string_like(lhs.as_ref()) || is_string_like(rhs.as_ref())
+        }
+        _ => false,
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS40StringConcatInLoop {
+    declaration_span: Option<Range<usize>>,
+    concat_span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS40StringConcatInLoop {
+    fn ident(&self) -> &'static str {
+        "L-S40"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#string_concat_in_loop")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        "String concatenation inside a loop can become slow; use an array and joinString instead".to_string()
+    }
+
+    fn label_message(&self) -> String {
+        "expensive string concatenation in loop".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("use an array of fragments and `joinString` after the loop".to_string())
+    }
+
+    fn note(&self) -> Option<String> {
+        Some("If the array being iterated is large, this can become slow".to_string())
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS40StringConcatInLoop {
+    #[must_use]
+    pub fn new(
+        declaration_span: Option<Range<usize>>,
+        concat_span: Range<usize>,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            declaration_span,
+            concat_span,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        let Some(mut diag) = Diagnostic::from_code_processed(&self, self.concat_span.clone(), processed) else {
+            return self;
+        };
+        diag = diag.clear_labels();
+        if let Some(span) = self.declaration_span.clone()
+            && let Some((file, span)) = get_span_info(span, processed) {
+                diag = diag.with_label(Label::secondary(file, span).with_message("accumulator declaration"));
+            }
+        if let Some((file, span)) = get_span_info(self.concat_span.clone(), processed) {
+            diag = diag.with_label(Label::primary(file, span).with_message("string concatenation in loop"));
+        }
+        self.diagnostic = Some(diag);
+        self
+    }
+}
+
+fn get_span_info(span: Range<usize>, processed: &Processed) -> Option<(WorkspacePath, Range<usize>)> {
+    let map_start = processed.mapping(span.start)?;
+    let map_end = processed.mapping(span.end)?;
+    let map_file = processed.source(map_start.source())?;
+    Some((
+        map_file.0.clone(),
+        map_start.original_start()..map_end.original_start(),
+    ))
+}

--- a/libs/sqf/src/analyze/lints/s41_foreach_apply.rs
+++ b/libs/sqf/src/analyze/lints/s41_foreach_apply.rs
@@ -1,0 +1,158 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::{LintConfig, LintEnabled};
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{
+    BinaryCommand, Expression, Statements,
+    analyze::LintData,
+};
+
+crate::analyze::lint!(LintS41ForeachApply);
+
+impl Lint<LintData> for LintS41ForeachApply {
+    fn ident(&self) -> &'static str {
+        "foreach_apply"
+    }
+
+    fn sort(&self) -> u32 {
+        410
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for forEach loops where `_forEachIndex` is never used"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+{
+    _values pushBack _x;
+} forEach bigArray;
+```
+
+**Correct**
+```sqf
+bigArray apply {
+    _values pushBack _x;
+};
+```
+
+### Explanation
+
+When a `forEach` loop never uses `_forEachIndex`, it can often be replaced with `apply`, which is the more idiomatic and typically faster form for array iteration.
+"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help().with_enabled(LintEnabled::Disabled)
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        let Expression::BinaryCommand(BinaryCommand::Named(command), lhs, _, _) = target else {
+            return Vec::new();
+        };
+        if !command.eq_ignore_ascii_case("foreach") && !command.eq_ignore_ascii_case("forEach") {
+            return Vec::new();
+        }
+
+        let Expression::Code(body) = lhs.as_ref() else {
+            return Vec::new();
+        };
+        if body_uses_for_each_index(body) {
+            return Vec::new();
+        }
+
+        vec![Arc::new(CodeS41ForeachApply::new(
+            target.span(),
+            processed,
+            config.severity(),
+        ))]
+    }
+}
+
+fn body_uses_for_each_index(statements: &Statements) -> bool {
+    statements.walk_expressions().iter().any(|expr| {
+        matches!(expr, Expression::Variable(name, _) if name.eq_ignore_ascii_case("_forEachIndex"))
+    })
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS41ForeachApply {
+    span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS41ForeachApply {
+    fn ident(&self) -> &'static str {
+        "L-S41"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#foreach_apply")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        "Use `apply` instead of `forEach` when `_forEachIndex` is unused".to_string()
+    }
+
+    fn label_message(&self) -> String {
+        "forEach loop can use apply".to_string()
+    }
+
+    fn help(&self) -> Option<String> {
+        Some("replace with `array apply { ... }`".to_string())
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS41ForeachApply {
+    #[must_use]
+    pub fn new(span: Range<usize>, processed: &Processed, severity: Severity) -> Self {
+        Self {
+            span,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s42_for_range.rs
+++ b/libs/sqf/src/analyze/lints/s42_for_range.rs
@@ -1,0 +1,237 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, Statement, Statements, UnaryCommand, analyze::LintData};
+
+crate::analyze::lint!(LintS42ForRange);
+
+impl Lint<LintData> for LintS42ForRange {
+    fn ident(&self) -> &'static str {
+        "for_range"
+    }
+
+    fn sort(&self) -> u32 {
+        420
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for `for [{},{},{}]` loops, where `for .. from .. to .. do` could be used instead"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+for [{_i = 0}, {_i < 10}, {_i = _i + 1}] do {
+    // code
+};
+```
+**Correct**
+```sqf
+for _i from 0 to 10 do {
+    // code
+};
+```
+
+### Explanation
+
+For loops using `for [{},{},{}]` are less efficient than using `for .. from .. to .. do`. The latter is more readable and performs better, as it avoids the overhead of evaluating the loop condition and increment expressions on each iteration.
+"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        let Expression::BinaryCommand(BinaryCommand::Named(cmd), lhs, _, _) = target else {
+            return Vec::new();
+        };
+        
+        if !cmd.eq_ignore_ascii_case("do") {
+            return Vec::new();
+        }
+
+        let Expression::UnaryCommand(UnaryCommand::Named(unary_cmd), lhs, for_span) = lhs.as_ref() else {
+            return Vec::new();
+        };
+        if !unary_cmd.eq_ignore_ascii_case("for") {
+            return Vec::new();
+        }
+        let span_start = for_span.start;
+
+        let Expression::Array(parts, _) = lhs.as_ref() else {
+            return Vec::new();
+        };
+
+        // First part is AssignGlobal
+        let Some(Expression::Code(Statements { content: statements, .. })) = parts.first() else {
+            return Vec::new();
+        };
+        if statements.len() != 1 {
+            return Vec::new();
+        }
+        let Some(Statement::AssignGlobal(variable, from_value, _)) = statements.first() else {
+            return Vec::new();
+        };
+        #[allow(clippy::cast_possible_truncation)]
+        let from_value = match from_value {
+            Expression::Number(n, _) => n.0 as i32,
+            _ => return Vec::new(),
+        };
+
+        // Second part is a comparison
+        let Some(Expression::Code(Statements { content: statements, .. })) = parts.get(1) else {
+            return Vec::new();
+        };
+        if statements.len() != 1 {
+            return Vec::new();
+        }
+        let Some(Statement::Expression(Expression::BinaryCommand(cmp_cmd, _, rhs, _), _)) = statements.first() else {
+            return Vec::new();
+        };
+        match cmp_cmd {
+            BinaryCommand::Less | BinaryCommand::LessEq | BinaryCommand::Greater | BinaryCommand::GreaterEq => {},
+            _ => return Vec::new(),
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let to_value = match rhs.as_ref() {
+            Expression::Number(n, _) => n.0 as i32,
+            _ => return Vec::new(),
+        };
+
+        // Third part is an increment
+        let Some(Expression::Code(Statements { content: statements, .. })) = parts.get(2) else {
+            return Vec::new();
+        };
+        if statements.len() != 1 {
+            return Vec::new();
+        }
+        let Some(Statement::AssignGlobal(_, assignment, _)) = statements.first() else {
+            return Vec::new();
+        };
+        let Expression::BinaryCommand(inc_command, _, inc_rhs, _) = assignment else {
+            return Vec::new();
+        };
+        #[allow(clippy::cast_possible_truncation)]
+        let step = match inc_command {
+            BinaryCommand::Add => match **inc_rhs {
+                Expression::Number(n, _) => n.0 as i32,
+                _ => return Vec::new(),
+            },
+            BinaryCommand::Sub => match **inc_rhs {
+                Expression::Number(n, _) => -(n.0 as i32),
+                _ => return Vec::new(),
+            },
+            _ => return Vec::new(),
+        };
+
+        vec![
+            Arc::new(CodeS42ForRange::new(
+                span_start..target.span().end,
+                processed,
+                config.severity(),
+                variable.clone(),
+                from_value,
+                to_value,
+                step,
+            ))
+        ]
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS42ForRange {
+    span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+    variable: String,
+    from_value: i32,
+    to_value: i32,
+    step: i32,
+}
+
+impl Code for CodeS42ForRange {
+    fn ident(&self) -> &'static str {
+        "L-S42"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#for_range")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        String::from("Use `for .. from .. to .. do` instead of `for [{{}},{{}},{{}}]`")
+    }
+
+    fn label_message(&self) -> String {
+        "use `for .. from .. to .. do`".to_string()
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        if self.step == 1 {
+            Some(format!("for {} from {} to {} do", self.variable, self.from_value, self.to_value))
+        } else {
+            Some(format!("for {} from {} to {} step {} do", self.variable, self.from_value, self.to_value, self.step))
+        }
+    }
+
+    // fn help(&self) -> Option<String> {
+    //     Some("Remove `_this` from the call".to_string())
+    // }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS42ForRange {
+    #[must_use]
+    pub fn new(span: Range<usize>, processed: &Processed, severity: Severity, variable: String, from_value: i32, to_value: i32, step: i32) -> Self {
+        Self {
+            span,
+            severity,
+            diagnostic: None,
+            variable,
+            from_value,
+            to_value,
+            step,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s43_array_setcount.rs
+++ b/libs/sqf/src/analyze/lints/s43_array_setcount.rs
@@ -1,0 +1,174 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{
+    BinaryCommand, Expression, UnaryCommand,
+    analyze::LintData,
+};
+
+crate::analyze::lint!(LintS43ArraySetcount);
+
+impl Lint<LintData> for LintS43ArraySetcount {
+    fn ident(&self) -> &'static str {
+        "array_setcount"
+    }
+
+    fn sort(&self) -> u32 {
+        430
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for appending to an array with `_array set [count _array, _value]`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+_a set [count _a, _value];
+```
+
+**Correct**
+```sqf
+_a pushBack _value;
+```
+
+### Explanation
+
+Using `set [count _array, value]` to append to an array is less clear and less idiomatic than `pushBack`. The latter communicates the intent directly and is the standard way to append values.
+"
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        let Expression::BinaryCommand(BinaryCommand::Named(command), lhs, rhs, _) = target else {
+            return Vec::new();
+        };
+        if !command.eq_ignore_ascii_case("set") {
+            return Vec::new();
+        }
+
+        let Expression::Array(parts, _) = rhs.as_ref() else {
+            return Vec::new();
+        };
+        if parts.len() != 2 {
+            return Vec::new();
+        }
+
+        let Some(index_expr) = parts.first() else {
+            return Vec::new();
+        };
+        let Some(value_expr) = parts.get(1) else {
+            return Vec::new();
+        };
+
+        let Expression::UnaryCommand(unary, array, _) = index_expr else {
+            return Vec::new();
+        };
+        if !matches!(unary, UnaryCommand::Named(name) if name.eq_ignore_ascii_case("count")) {
+            return Vec::new();
+        }
+
+        let array_source = array.source(false);
+        let lhs_source = lhs.source(false);
+        if array_source != lhs_source {
+            return Vec::new();
+        }
+
+        vec![Arc::new(CodeS43ArraySetcount::new(
+            target.full_span(),
+            processed,
+            config.severity(),
+            lhs_source,
+            value_expr.source(false),
+        ))]
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS43ArraySetcount {
+    span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+    array: String,
+    value: String,
+}
+
+impl Code for CodeS43ArraySetcount {
+    fn ident(&self) -> &'static str {
+        "L-S43"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#array_setcount")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        "Use `pushBack` instead of `set [count _array, value]`".to_string()
+    }
+
+    fn label_message(&self) -> String {
+        "array append can use pushBack".to_string()
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("{} pushBack {}", self.array, self.value))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS43ArraySetcount {
+    #[must_use]
+    pub fn new(span: Range<usize>, processed: &Processed, severity: Severity, array: String, value: String) -> Self {
+        Self {
+            span,
+            severity,
+            diagnostic: None,
+            array,
+            value,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s44_string_concat_format.rs
+++ b/libs/sqf/src/analyze/lints/s44_string_concat_format.rs
@@ -1,0 +1,236 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{
+    BinaryCommand, Expression, Statement, UnaryCommand, analyze::LintData,
+};
+
+crate::analyze::lint!(LintS44StringConcatFormat);
+
+impl Lint<LintData> for LintS44StringConcatFormat {
+    fn ident(&self) -> &'static str {
+        "string_concat_format"
+    }
+
+    fn sort(&self) -> u32 {
+        440
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for string concatenation chains and suggests `format`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Example
+
+**Incorrect**
+```sqf
+private _person = _first + " " + _last + ", " + str _age + " years old";
+```
+
+**Correct**
+```sqf
+private _person = format ["%1 %2, %3 years old", _first, _last, _age];
+```
+
+### Explanation
+
+Chaining string concatenation with `+` can be harder to read and maintain than using `format`, especially when values are mixed with literals.
+"#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Statement;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        let expression = match target {
+            Statement::Expression(expression, _) => expression,
+            Statement::AssignLocal(_, expression, _) | Statement::AssignGlobal(_, expression, _) => {
+                expression
+            }
+        };
+
+        let Some((_, best_expr)) = find_best_concat_chain(expression) else {
+            return Vec::new();
+        };
+
+        let mut parts = Vec::new();
+        collect_concat_parts(best_expr, &mut parts);
+        if parts.len() < 3 {
+            return Vec::new();
+        }
+
+        let Some(format_replacement) = build_format_suggestion(&parts) else {
+            return Vec::new();
+        };
+
+        vec![Arc::new(CodeS44StringConcatFormat::new(
+            expression.full_span(),
+            processed,
+            config.severity(),
+            format_replacement,
+        ))]
+    }
+}
+
+fn find_best_concat_chain(expr: &Expression) -> Option<(usize, &Expression)> {
+    match expr {
+        Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) => {
+            let current_parts = collect_concat_parts_count(expr);
+            let lhs_best = find_best_concat_chain(lhs);
+            let rhs_best = find_best_concat_chain(rhs);
+
+            let best_child = lhs_best.iter().chain(rhs_best.iter()).max_by_key(|(count, _)| *count);
+            match best_child {
+                Some((child_count, child_expr)) if *child_count > current_parts => {
+                    Some((*child_count, child_expr))
+                }
+                _ if current_parts >= 3 && contains_string_literal(expr) => {
+                    Some((current_parts, expr))
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn collect_concat_parts_count(expr: &Expression) -> usize {
+    let mut parts = Vec::new();
+    collect_concat_parts(expr, &mut parts);
+    parts.len()
+}
+
+fn contains_string_literal(expr: &Expression) -> bool {
+    match expr {
+        Expression::String(_, _, _) => true,
+        Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) => {
+            contains_string_literal(lhs) || contains_string_literal(rhs)
+        }
+        _ => false,
+    }
+}
+
+fn collect_concat_parts(expr: &Expression, parts: &mut Vec<String>) {
+    match expr {
+        Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) => {
+            collect_concat_parts(lhs, parts);
+            collect_concat_parts(rhs, parts);
+        }
+        Expression::String(value, _, _) => parts.push(format!("\"{value}\"")),
+        Expression::Variable(name, _) => parts.push(name.clone()),
+        Expression::UnaryCommand(UnaryCommand::Named(cmd), inner, _) => {
+            if cmd.eq_ignore_ascii_case("str") {
+                parts.push(inner.source(false));
+            } else {
+                parts.push(expr.source(false));
+            }
+        }
+        _ => parts.push(expr.source(false)),
+    }
+}
+
+fn build_format_suggestion(parts: &[String]) -> Option<String> {
+    let mut format_parts = Vec::new();
+    let mut placeholders = Vec::new();
+
+    for part in parts {
+        if let Some(stripped) = part.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+            format_parts.push(stripped.replace('%', "%%"));
+        } else {
+            placeholders.push(part.clone());
+            format_parts.push(format!("%{}", placeholders.len()));
+        }
+    }
+
+    if placeholders.is_empty() {
+        return None;
+    }
+
+    let format_string = format_parts.join("");
+    let args = placeholders.join(", ");
+    Some(format!("format [\"{format_string}\", {args}]") )
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS44StringConcatFormat {
+    span: Range<usize>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+    suggestion: String,
+}
+
+impl Code for CodeS44StringConcatFormat {
+    fn ident(&self) -> &'static str {
+        "L-S44"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#string_concat_format")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        "Use `format` instead of string concatenation".to_string()
+    }
+
+    fn label_message(&self) -> String {
+        "chained concatenation".to_string()
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(self.suggestion.clone())
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS44StringConcatFormat {
+    #[must_use]
+    pub fn new(span: Range<usize>, processed: &Processed, severity: Severity, suggestion: String) -> Self {
+        Self {
+            span,
+            severity,
+            diagnostic: None,
+            suggestion,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s44_string_concat_format.rs
+++ b/libs/sqf/src/analyze/lints/s44_string_concat_format.rs
@@ -7,7 +7,7 @@ use hemtt_workspace::{
 };
 
 use crate::{
-    BinaryCommand, Expression, Statement, UnaryCommand, analyze::LintData,
+    BinaryCommand, Expression, Statement, analyze::LintData,
 };
 
 crate::analyze::lint!(LintS44StringConcatFormat);
@@ -45,7 +45,7 @@ Chaining string concatenation with `+` can be harder to read and maintain than u
     }
 
     fn default_config(&self) -> LintConfig {
-        LintConfig::help()
+        LintConfig::help().with_enabled(hemtt_common::config::LintEnabled::Disabled)
     }
 
     fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
@@ -146,12 +146,8 @@ fn collect_concat_parts(expr: &Expression, parts: &mut Vec<String>) {
         }
         Expression::String(value, _, _) => parts.push(format!("\"{value}\"")),
         Expression::Variable(name, _) => parts.push(name.clone()),
-        Expression::UnaryCommand(UnaryCommand::Named(cmd), inner, _) => {
-            if cmd.eq_ignore_ascii_case("str") {
-                parts.push(inner.source(false));
-            } else {
-                parts.push(expr.source(false));
-            }
+        Expression::UnaryCommand(_, _, _) => {
+            parts.push(expr.source(false));
         }
         _ => parts.push(expr.source(false)),
     }

--- a/libs/sqf/src/lib.rs
+++ b/libs/sqf/src/lib.rs
@@ -46,6 +46,25 @@ impl Statements {
     pub const fn issues(&self) -> &Vec<Issue> {
         &self.issues
     }
+
+    #[must_use]
+    pub fn walk_statements(&self) -> Vec<&Statement> {
+        let mut root = vec![];
+        for statement in &self.content {
+            root.extend(statement.walk_statements());
+        }
+        root
+    }
+
+    #[must_use]
+    pub fn walk_expressions(&self) -> Vec<&Expression> {
+        let mut root = vec![];
+        for statement in &self.content {
+            root.extend(statement.walk_expressions());
+        }
+        root
+    }
+
     #[must_use]
     /// Gets the highest version required by any command in this code chunk.
     pub fn required_version(&self, database: &Database) -> (String, Version, Range<usize>) {
@@ -108,6 +127,7 @@ impl Statements {
         }
         (command, version, span)
     }
+
     pub fn testing_clear_issues(&mut self) {
         self.issues.clear();
     }
@@ -259,9 +279,7 @@ impl Expression {
         let mut root = vec![self];
         match self {
             Self::Code(code) => {
-                for statement in code.content() {
-                    root.extend(statement.walk_expressions());
-                }
+                root.extend(code.walk_expressions());
             }
             Self::UnaryCommand(_, child, _) => {
                 root.extend(child.walk_expressions());

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -12,11 +12,11 @@ use hemtt_workspace::{LayerType, addons::Addon, position::Position, reporting::W
 const ROOT: &str = "tests/lints/";
 
 macro_rules! lint {
-    ($dir:ident, $ignore:expr) => {
+    ($dir:ident, $ignore_inspector:expr) => {
         paste::paste! {
             #[test]
             fn [<simple_ $dir>]() {
-                insta::assert_snapshot!(lint(stringify!($dir), $ignore).0);
+                insta::assert_snapshot!(lint(stringify!($dir), $ignore_inspector).0);
             }
         }
     };
@@ -73,6 +73,13 @@ lint!(s33_mod, true);
 lint!(s33_pi, true);
 lint!(s35_count_skipable, true);
 lint!(s36_global_var_in_local, true);
+lint!(s38_direct_private, true);
+lint!(s39_replaced_functions, true);
+lint!(s40_string_concat_in_loop, true);
+lint!(s41_foreach_apply, true);
+lint!(s42_for_range, true);
+lint!(s43_array_setcount, true);
+lint!(s44_string_concat_format, true);
 
 #[test]
 fn test_s29_function_undefined() {

--- a/libs/sqf/tests/lints/project_tests.toml
+++ b/libs/sqf/tests/lints/project_tests.toml
@@ -46,3 +46,6 @@ options.always = [
 
 [lints.sqf.count_skipable]
 enabled = true
+
+[lints.sqf.foreach_apply]
+enabled = true

--- a/libs/sqf/tests/lints/s38_direct_private.sqf
+++ b/libs/sqf/tests/lints/s38_direct_private.sqf
@@ -1,0 +1,18 @@
+private ["_a", "_b", "_c", "_d"];
+_a = 1;
+_b = 2;
+_c = 3;
+_d = 4;
+
+private "_e";
+_e = 5;
+
+private ["_x"];
+_x = 5;
+
+private _y = 10;
+
+private ["_z"];
+[1,2,3] apply {
+    _z = _z + _x;
+};

--- a/libs/sqf/tests/lints/s39_replaced_functions.sqf
+++ b/libs/sqf/tests/lints/s39_replaced_functions.sqf
@@ -1,0 +1,3 @@
+[1,2,3] call BIS_fnc_selectRandom;
+
+[[1,2,3], 3] call BIS_fnc_vectorMultiply;

--- a/libs/sqf/tests/lints/s40_string_concat_in_loop.sqf
+++ b/libs/sqf/tests/lints/s40_string_concat_in_loop.sqf
@@ -1,0 +1,29 @@
+private _myString = "";
+for "_i" from 0 to 10000 do {
+    _myString = _myString + "123";
+};
+
+private _myString2 = "";
+for [{ _i = 0 }, { _i < 10000 }, { _i = _i + 1 }] do {
+    _myString2 = _myString2 + "123";
+};
+
+private _smallString = "";
+for "_i" from 0 to 10 do {
+    _smallString = _smallString + "x";
+};
+
+private _names = "";
+GlobalNames apply {
+    _names = _names + _x;
+};
+
+private _addonsList = [];
+(entities "all") apply {
+    _addonsList = _addonsList + (unitAddons typeOf _x);
+};
+
+private _addonsList = "";
+(entities "all") apply {
+    _addonsList = _addonsList + format["%1, ", unitAddons typeOf _x];
+};

--- a/libs/sqf/tests/lints/s41_foreach_apply.sqf
+++ b/libs/sqf/tests/lints/s41_foreach_apply.sqf
@@ -1,0 +1,14 @@
+private _values = [];
+{
+    _values pushBack _x;
+} forEach bigArray;
+
+private _values2 = [];
+{
+    _values2 pushBack _forEachIndex;
+} forEach bigArray;
+
+private _values3 = [];
+{
+    _values3 pushBack (format ["%1", _x]);
+} forEach [1, 2, 3];

--- a/libs/sqf/tests/lints/s42_for_range.sqf
+++ b/libs/sqf/tests/lints/s42_for_range.sqf
@@ -1,0 +1,3 @@
+for [{ _i = 0 }, { _i < 10 }, { _i = _i + 1 }] do { /* forCode */ };
+
+for [{ _i = 10 }, { _i > 0 }, { _i = _i - 1 }] do { /* forCode */ };

--- a/libs/sqf/tests/lints/s43_array_setcount.sqf
+++ b/libs/sqf/tests/lints/s43_array_setcount.sqf
@@ -1,0 +1,6 @@
+_a set [count _a, _value];
+
+_a set [count _a, _value];
+
+private _b = [];
+_b set [count _b, 42];

--- a/libs/sqf/tests/lints/s44_string_concat_format.sqf
+++ b/libs/sqf/tests/lints/s44_string_concat_format.sqf
@@ -5,3 +5,5 @@ private _text = "Hello" + " " + _name;
 private _title = localize "STR_TITLE" + " - " + _subtitle;
 
 private _message = "We are " + str _progress + "% done.";
+
+private _script = "player addEventHandler ['Fired', " + str x + "];";

--- a/libs/sqf/tests/lints/s44_string_concat_format.sqf
+++ b/libs/sqf/tests/lints/s44_string_concat_format.sqf
@@ -1,0 +1,7 @@
+private _person = _first + " " + _last + ", " + str _age + " years old";
+
+private _text = "Hello" + " " + _name;
+
+private _title = localize "STR_TITLE" + " - " + _subtitle;
+
+private _message = "We are " + str _progress + "% done.";

--- a/libs/sqf/tests/snapshots/lints__simple_s38_direct_private.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s38_direct_private.snap
@@ -1,0 +1,71 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s38_direct_private), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S38][0m[1m: Use `private _a = <value>` instead of declaring then assigning[0m
+  [0m[36m┌─[0m s38_direct_private.sqf:2:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m private ["_a", "_b", "_c", "_d"];
+  [0m[36m│[0m          [0m[36m----[0m [0m[36mdeclaration[0m
+[0m[36m2[0m [0m[36m│[0m [0m[36m_a = 1[0m;
+  [0m[36m│[0m [0m[36m^^^^^^[0m [0m[36massignment[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: private _a = <value>
+
+
+[0m[1m[38;5;14mhelp[L-S38][0m[1m: Use `private _b = <value>` instead of declaring then assigning[0m
+  [0m[36m┌─[0m s38_direct_private.sqf:3:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m private ["_a", "_b", "_c", "_d"];
+  [0m[36m│[0m                [0m[36m----[0m [0m[36mdeclaration[0m
+[0m[36m2[0m [0m[36m│[0m _a = 1;
+[0m[36m3[0m [0m[36m│[0m [0m[36m_b = 2[0m;
+  [0m[36m│[0m [0m[36m^^^^^^[0m [0m[36massignment[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: private _b = <value>
+
+
+[0m[1m[38;5;14mhelp[L-S38][0m[1m: Use `private _c = <value>` instead of declaring then assigning[0m
+  [0m[36m┌─[0m s38_direct_private.sqf:4:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m private ["_a", "_b", "_c", "_d"];
+  [0m[36m│[0m                      [0m[36m----[0m [0m[36mdeclaration[0m
+  [0m[36m·[0m
+[0m[36m4[0m [0m[36m│[0m [0m[36m_c = 3[0m;
+  [0m[36m│[0m [0m[36m^^^^^^[0m [0m[36massignment[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: private _c = <value>
+
+
+[0m[1m[38;5;14mhelp[L-S38][0m[1m: Use `private _d = <value>` instead of declaring then assigning[0m
+  [0m[36m┌─[0m s38_direct_private.sqf:5:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m private ["_a", "_b", "_c", "_d"];
+  [0m[36m│[0m                            [0m[36m----[0m [0m[36mdeclaration[0m
+  [0m[36m·[0m
+[0m[36m5[0m [0m[36m│[0m [0m[36m_d = 4[0m;
+  [0m[36m│[0m [0m[36m^^^^^^[0m [0m[36massignment[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: private _d = <value>
+
+
+[0m[1m[38;5;14mhelp[L-S38][0m[1m: Use `private _e = <value>` instead of declaring then assigning[0m
+  [0m[36m┌─[0m s38_direct_private.sqf:8:1
+  [0m[36m│[0m
+[0m[36m7[0m [0m[36m│[0m private "_e";
+  [0m[36m│[0m         [0m[36m----[0m [0m[36mdeclaration[0m
+[0m[36m8[0m [0m[36m│[0m [0m[36m_e = 5[0m;
+  [0m[36m│[0m [0m[36m^^^^^^[0m [0m[36massignment[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: private _e = <value>
+
+
+[0m[1m[38;5;14mhelp[L-S38][0m[1m: Use `private _x = <value>` instead of declaring then assigning[0m
+   [0m[36m┌─[0m s38_direct_private.sqf:11:1
+   [0m[36m│[0m
+[0m[36m10[0m [0m[36m│[0m private ["_x"];
+   [0m[36m│[0m          [0m[36m----[0m [0m[36mdeclaration[0m
+[0m[36m11[0m [0m[36m│[0m [0m[36m_x = 5[0m;
+   [0m[36m│[0m [0m[36m^^^^^^[0m [0m[36massignment[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: private _x = <value>

--- a/libs/sqf/tests/snapshots/lints__simple_s39_replaced_functions.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s39_replaced_functions.snap
@@ -1,0 +1,20 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s39_replaced_functions), true).0"
+---
+[0m[1m[38;5;11mwarning[L-S39][0m[1m: Function has been replaced by command: `selectRandom`[0m
+  [0m[36m┌─[0m s39_replaced_functions.sqf:1:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m [0m[33m[1,2,3] call BIS_fnc_selectRandom[0m;
+  [0m[36m│[0m [0m[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[33muse `selectRandom`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: selectRandom [1,2,3]
+
+
+[0m[1m[38;5;11mwarning[L-S39][0m[1m: Function has been replaced by command: `vectorMultiply`[0m
+  [0m[36m┌─[0m s39_replaced_functions.sqf:3:1
+  [0m[36m│[0m
+[0m[36m3[0m [0m[36m│[0m [0m[33m[[1,2,3], 3] call BIS_fnc_vectorMultiply[0m;
+  [0m[36m│[0m [0m[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[33muse `vectorMultiply`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: [1,2,3] vectorMultiply 3

--- a/libs/sqf/tests/snapshots/lints__simple_s40_string_concat_in_loop.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s40_string_concat_in_loop.snap
@@ -1,0 +1,37 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s40_string_concat_in_loop), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S40][0m[1m: String concatenation inside a loop can become slow; use an array and joinString instead[0m
+  [0m[36m┌─[0m s40_string_concat_in_loop.sqf:3:5
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m private _myString = "";
+  [0m[36m│[0m [0m[36m----------------------[0m [0m[36maccumulator declaration[0m
+[0m[36m2[0m [0m[36m│[0m for "_i" from 0 to 10000 do {
+[0m[36m3[0m [0m[36m│[0m     [0m[36m_myString = _myString + "123"[0m;
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mstring concatenation in loop[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: If the array being iterated is large, this can become slow
+  [0m[36m=[0m [33mhelp[0m: use an array of fragments and `joinString` after the loop
+
+
+[0m[1m[38;5;14mhelp[L-S40][0m[1m: String concatenation inside a loop can become slow; use an array and joinString instead[0m
+  [0m[36m┌─[0m s40_string_concat_in_loop.sqf:8:5
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m private _myString2 = "";
+  [0m[36m│[0m [0m[36m-----------------------[0m [0m[36maccumulator declaration[0m
+[0m[36m7[0m [0m[36m│[0m for [{ _i = 0 }, { _i < 10000 }, { _i = _i + 1 }] do {
+[0m[36m8[0m [0m[36m│[0m     [0m[36m_myString2 = _myString2 + "123"[0m;
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mstring concatenation in loop[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: If the array being iterated is large, this can become slow
+  [0m[36m=[0m [33mhelp[0m: use an array of fragments and `joinString` after the loop
+
+
+[0m[1m[38;5;14mhelp[L-S42][0m[1m: Use `for .. from .. to .. do` instead of `for [{{}},{{}},{{}}]`[0m
+  [0m[36m┌─[0m s40_string_concat_in_loop.sqf:7:1
+  [0m[36m│[0m
+[0m[36m7[0m [0m[36m│[0m [0m[36mfor [{ _i = 0 }, { _i < 10000 }, { _i = _i + 1 }] do[0m {
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `for .. from .. to .. do`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: for _i from 0 to 10000 do

--- a/libs/sqf/tests/snapshots/lints__simple_s41_foreach_apply.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s41_foreach_apply.snap
@@ -1,0 +1,20 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s41_foreach_apply), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S41][0m[1m: Use `apply` instead of `forEach` when `_forEachIndex` is unused[0m
+  [0m[36m┌─[0m s41_foreach_apply.sqf:4:3
+  [0m[36m│[0m
+[0m[36m4[0m [0m[36m│[0m } [0m[36mforEach[0m bigArray;
+  [0m[36m│[0m   [0m[36m^^^^^^^[0m [0m[36mforEach loop can use apply[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [33mhelp[0m: replace with `array apply { ... }`
+
+
+[0m[1m[38;5;14mhelp[L-S41][0m[1m: Use `apply` instead of `forEach` when `_forEachIndex` is unused[0m
+   [0m[36m┌─[0m s41_foreach_apply.sqf:14:3
+   [0m[36m│[0m
+[0m[36m14[0m [0m[36m│[0m } [0m[36mforEach[0m [1, 2, 3];
+   [0m[36m│[0m   [0m[36m^^^^^^^[0m [0m[36mforEach loop can use apply[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [33mhelp[0m: replace with `array apply { ... }`

--- a/libs/sqf/tests/snapshots/lints__simple_s42_for_range.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s42_for_range.snap
@@ -1,0 +1,20 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s42_for_range), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S42][0m[1m: Use `for .. from .. to .. do` instead of `for [{{}},{{}},{{}}]`[0m
+  [0m[36m┌─[0m s42_for_range.sqf:1:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m [0m[36mfor [{ _i = 0 }, { _i < 10 }, { _i = _i + 1 }] do[0m { /* forCode */ };
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `for .. from .. to .. do`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: for _i from 0 to 10 do
+
+
+[0m[1m[38;5;14mhelp[L-S42][0m[1m: Use `for .. from .. to .. do` instead of `for [{{}},{{}},{{}}]`[0m
+  [0m[36m┌─[0m s42_for_range.sqf:3:1
+  [0m[36m│[0m
+[0m[36m3[0m [0m[36m│[0m [0m[36mfor [{ _i = 10 }, { _i > 0 }, { _i = _i - 1 }] do[0m { /* forCode */ };
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `for .. from .. to .. do`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: for _i from 10 to 0 step -1 do

--- a/libs/sqf/tests/snapshots/lints__simple_s43_array_setcount.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s43_array_setcount.snap
@@ -1,0 +1,29 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s43_array_setcount), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S43][0m[1m: Use `pushBack` instead of `set [count _array, value]`[0m
+  [0m[36m┌─[0m s43_array_setcount.sqf:1:1
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m [0m[36m_a set [count _a, _value][0m;
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray append can use pushBack[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _a pushBack _value
+
+
+[0m[1m[38;5;14mhelp[L-S43][0m[1m: Use `pushBack` instead of `set [count _array, value]`[0m
+  [0m[36m┌─[0m s43_array_setcount.sqf:3:1
+  [0m[36m│[0m
+[0m[36m3[0m [0m[36m│[0m [0m[36m_a set [count _a, _value][0m;
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray append can use pushBack[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _a pushBack _value
+
+
+[0m[1m[38;5;14mhelp[L-S43][0m[1m: Use `pushBack` instead of `set [count _array, value]`[0m
+  [0m[36m┌─[0m s43_array_setcount.sqf:6:1
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m [0m[36m_b set [count _b, 42][0m;
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray append can use pushBack[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _b pushBack 42

--- a/libs/sqf/tests/snapshots/lints__simple_s44_string_concat_format.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s44_string_concat_format.snap
@@ -1,0 +1,39 @@
+---
+source: libs/sqf/tests/lints.rs
+assertion_line: 82
+expression: "lint(stringify! (s44_string_concat_format), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S44][0m[1m: Use `format` instead of string concatenation[0m
+  [0m[36m┌─[0m s44_string_concat_format.sqf:1:19
+  [0m[36m│[0m
+[0m[36m1[0m [0m[36m│[0m private _person = [0m[36m_first + " " + _last + ", " + str _age + " years old"[0m;
+  [0m[36m│[0m                   [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: format ["%1 %2, %3 years old", _first, _last, _age]
+
+
+[0m[1m[38;5;14mhelp[L-S44][0m[1m: Use `format` instead of string concatenation[0m
+  [0m[36m┌─[0m s44_string_concat_format.sqf:3:17
+  [0m[36m│[0m
+[0m[36m3[0m [0m[36m│[0m private _text = [0m[36m"Hello" + " " + _name[0m;
+  [0m[36m│[0m                 [0m[36m^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: format ["Hello %1", _name]
+
+
+[0m[1m[38;5;14mhelp[L-S44][0m[1m: Use `format` instead of string concatenation[0m
+  [0m[36m┌─[0m s44_string_concat_format.sqf:5:18
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m private _title = [0m[36mlocalize "STR_TITLE" + " - " + _subtitle[0m;
+  [0m[36m│[0m                  [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: format ["%1 - %2", localize "STR_TITLE", _subtitle]
+
+
+[0m[1m[38;5;14mhelp[L-S44][0m[1m: Use `format` instead of string concatenation[0m
+  [0m[36m┌─[0m s44_string_concat_format.sqf:7:20
+  [0m[36m│[0m
+[0m[36m7[0m [0m[36m│[0m private _message = [0m[36m"We are " + str _progress + "% done."[0m;
+  [0m[36m│[0m                    [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: format ["We are %1%% done.", _progress]

--- a/libs/sqf/tests/snapshots/lints__simple_s44_string_concat_format.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s44_string_concat_format.snap
@@ -9,7 +9,7 @@ expression: "lint(stringify! (s44_string_concat_format), true).0"
 [0m[36m1[0m [0m[36m│[0m private _person = [0m[36m_first + " " + _last + ", " + str _age + " years old"[0m;
   [0m[36m│[0m                   [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
   [0m[36m│[0m
-  [0m[36m=[0m [32mtry[0m: format ["%1 %2, %3 years old", _first, _last, _age]
+  [0m[36m=[0m [32mtry[0m: format ["%1 %2, %3 years old", _first, _last, str _age]
 
 
 [0m[1m[38;5;14mhelp[L-S44][0m[1m: Use `format` instead of string concatenation[0m
@@ -36,4 +36,13 @@ expression: "lint(stringify! (s44_string_concat_format), true).0"
 [0m[36m7[0m [0m[36m│[0m private _message = [0m[36m"We are " + str _progress + "% done."[0m;
   [0m[36m│[0m                    [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
   [0m[36m│[0m
-  [0m[36m=[0m [32mtry[0m: format ["We are %1%% done.", _progress]
+  [0m[36m=[0m [32mtry[0m: format ["We are %1%% done.", str _progress]
+
+
+[0m[1m[38;5;14mhelp[L-S44][0m[1m: Use `format` instead of string concatenation[0m
+  [0m[36m┌─[0m s44_string_concat_format.sqf:9:19
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m private _script = [0m[36m"player addEventHandler ['Fired', " + str x + "];"[0m;
+  [0m[36m│[0m                   [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mchained concatenation[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: format ["player addEventHandler ['Fired', %1];", str x]


### PR DESCRIPTION
* **S38: DirectPrivate** Warns when a private variable is declared and then assigned in a separate statement, suggesting the use of direct initialization instead.
* **S39: ReplacedFunctions** Detects usage of BIS functions that have been replaced by native SQF commands, recommending the modern command equivalents.
* **S41: ForeachApply** Suggests replacing `forEach` loops with `apply` when the loop index variable (`_forEachIndex`) is not used.
* **S42: ForRange** Detects `for [{},{},{}]` loop patterns and recommends the more efficient `for .. from .. to .. do` syntax.