### PR TITLE
sqf: S03 - Report non-finite numbers as `NaN`

### DIFF
--- a/libs/sqf/src/analyze/lints/s03_static_typename.rs
+++ b/libs/sqf/src/analyze/lints/s03_static_typename.rs
@@ -76,7 +76,12 @@ impl LintRunner<LintData> for Runner {
         let target_span = expresssion.span();
         let (constant_type, span, length) = match &**expresssion {
             Expression::String(s, span, _) => ("STRING", span, s.len() + 2),
-            Expression::Number(FloatOrd(s), span) => ("SCALAR", span, s.to_string().len()),
+            // a literal the engine cannot represent as a finite number reports as NaN, not SCALAR
+            Expression::Number(FloatOrd(s), span) => (
+                if s.is_finite() { "SCALAR" } else { "NaN" },
+                span,
+                s.to_string().len(),
+            ),
             Expression::Boolean(bool, span) => ("BOOL", span, bool.to_string().len()),
             Expression::Code(statements) if statements.content().is_empty() => {
                 ("CODE", &target_span, statements.span().len())

--- a/libs/sqf/tests/lints/s03_static_typename.sqf
+++ b/libs/sqf/tests/lints/s03_static_typename.sqf
@@ -7,3 +7,6 @@ if (typeName 0 == typeName _thing) then {
 };
 
 private _aliveIsBool = typeName true == typeName alive player;
+
+// a number the engine cannot represent is NaN, not SCALAR
+hint typeName 1e39;

--- a/libs/sqf/tests/snapshots/lints__simple_s03_static_typename.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s03_static_typename.snap
@@ -1,6 +1,6 @@
 ---
 source: libs/sqf/tests/lints.rs
-expression: lint(stringify! (s03_static_typename))
+expression: "lint(stringify! (s03_static_typename), true).0"
 ---
 [0m[1m[38;5;11mwarning[L-S03][0m[1m: using `typeName` on a constant is slower than using the type directly[0m
   [0m[36m┌─[0m s03_static_typename.sqf:1:6
@@ -27,3 +27,12 @@ expression: lint(stringify! (s03_static_typename))
   [0m[36m│[0m                        [0m[33m^^^^^^^^^^^^^[0m [0m[33m`typeName` on a constant[0m
   [0m[36m│[0m
   [0m[36m=[0m [32mtry[0m: "BOOL"
+
+
+[0m[1m[38;5;11mwarning[L-S03][0m[1m: using `typeName` on a constant is slower than using the type directly[0m
+   [0m[36m┌─[0m s03_static_typename.sqf:12:6
+   [0m[36m│[0m
+[0m[36m12[0m [0m[36m│[0m hint [0m[33mtypeName 1e39[0m;
+   [0m[36m│[0m      [0m[33m^^^^^^^^^^^^^[0m [0m[33m`typeName` on a constant[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: "NaN"


### PR DESCRIPTION
`typeName` on a numeric literal the engine cannot represent as a finite number returns "NaN", not "SCALAR". The lint mapped every Number to "SCALAR", so it suggested the wrong replacement for those literals.