### PR TITLE
sqf: S39 - Add `BIS_fnc_paramIn`

### DIFF
--- a/libs/sqf/src/analyze/lints/s39_replaced_functions.rs
+++ b/libs/sqf/src/analyze/lints/s39_replaced_functions.rs
@@ -66,6 +66,7 @@ const REPLACED_FUNCTIONS: &[(&str, &str, ReplacedShaped)] = &[
     ("BIS_fnc_vectorDiff", "vectorDiff", ReplacedShaped::Binary),
     ("BIS_fnc_linearConversion", "linearConversion", ReplacedShaped::Unary),
     ("BIS_fnc_param", "param", ReplacedShaped::Unary),
+    ("BIS_fnc_paramIn", "param", ReplacedShaped::Unary),
     ("BIS_fnc_MP", "remoteExec", ReplacedShaped::Unary),
 ];
 

--- a/libs/sqf/tests/lints/s39_replaced_functions.sqf
+++ b/libs/sqf/tests/lints/s39_replaced_functions.sqf
@@ -1,3 +1,6 @@
 [1,2,3] call BIS_fnc_selectRandom;
 
 [[1,2,3], 3] call BIS_fnc_vectorMultiply;
+
+private _parent = [_this, 0, [], [[]]] call BIS_fnc_param;
+private _child = [_parent, 1, "", [""]] call BIS_fnc_paramIn;

--- a/libs/sqf/tests/snapshots/lints__simple_s39_replaced_functions.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s39_replaced_functions.snap
@@ -2,6 +2,20 @@
 source: libs/sqf/tests/lints.rs
 expression: "lint(stringify! (s39_replaced_functions), true).0"
 ---
+[0m[1m[38;5;11mwarning[L-S39][0m[1m: Function has been replaced by command: `param`[0m
+  [0m[36m┌─[0m s39_replaced_functions.sqf:5:19
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m private _parent = [0m[33m[_this, 0, [], [[]]] call BIS_fnc_param[0m;
+  [0m[36m│[0m                   [0m[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[33muse `param`[0m
+
+
+[0m[1m[38;5;11mwarning[L-S39][0m[1m: Function has been replaced by command: `param`[0m
+  [0m[36m┌─[0m s39_replaced_functions.sqf:6:18
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m private _child = [0m[33m[_parent, 1, "", [""]] call BIS_fnc_paramIn[0m;
+  [0m[36m│[0m                  [0m[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[33muse `param`[0m
+
+
 [0m[1m[38;5;11mwarning[L-S39][0m[1m: Function has been replaced by command: `selectRandom`[0m
   [0m[36m┌─[0m s39_replaced_functions.sqf:1:1
   [0m[36m│[0m


### PR DESCRIPTION
`BIS_fnc_paramIn` takes the same arguments as `BIS_fnc_param` and is likewise replaced by the `param` command. It differs only in having default value overloading disabled.