### PR TITLE
sqf: S26 - Report comparisons in short circuit blocks

### DIFF
--- a/libs/sqf/src/analyze/lints/s26_short_circuit_bool_var.rs
+++ b/libs/sqf/src/analyze/lints/s26_short_circuit_bool_var.rs
@@ -29,16 +29,28 @@ impl Lint<LintData> for LintS26ShortCircuitBoolVar {
 **Incorrect**
 ```sqf
 if (_test1 && {_test2}) then { };
+if (_test1 && {_a isEqualTo _b}) then { };
 ```
 **Correct**
 ```sqf
 if (_test1 && _test2) then { };
+if (_test1 && _a isEqualTo _b) then { };
 ```
 
 ### Explanation
 
-Short circuit evaultion on a variable that is a boolean is inefficient
-False positives are possible if the var could be undefined, e.g.:
+Short circuit evaluation is not free: the right hand side is a code block that has to be
+created and called. When the right hand side is just a boolean variable, or a comparison
+between simple values, evaluating it eagerly is cheaper than the short circuit that skips it.
+
+Comparisons are only reported when both sides are simple values (a variable, number, string
+or boolean). A comparison that calls a command is left alone, because the short circuit is
+often guarding it:
+```sqf
+if (count _array > 0 && {_array select 0 isEqualTo "x"}) then { }; // not reported
+```
+
+False positives are possible if a variable could be undefined, e.g.:
 ```sqf
 someLogic = !isNil "z";
 someLogic && {z}
@@ -53,6 +65,39 @@ someLogic && {z}
     fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
         vec![Box::new(Runner)]
     }
+}
+
+/// Comparisons that are cheaper to evaluate eagerly than to short circuit around.
+fn is_comparison(cmd: &BinaryCommand) -> bool {
+    match cmd {
+        BinaryCommand::Eq
+        | BinaryCommand::NotEq
+        | BinaryCommand::Greater
+        | BinaryCommand::Less
+        | BinaryCommand::GreaterEq
+        | BinaryCommand::LessEq => true,
+        BinaryCommand::Named(name) => [
+            "isEqualTo",
+            "isNotEqualTo",
+            "isEqualRef",
+            "isNotEqualRef",
+            "isEqualType",
+        ]
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate)),
+        _ => false,
+    }
+}
+
+/// A value that can be evaluated without calling a command, so it cannot error or have side effects.
+const fn is_simple_operand(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::Variable(..)
+            | Expression::Number(..)
+            | Expression::String(..)
+            | Expression::Boolean(..)
+    )
 }
 
 struct Runner;
@@ -83,22 +128,38 @@ impl LintRunner<LintData> for Runner {
         if statements.content().len() != 1 { 
             return Vec::new()
         }
-        let Statement::Expression(Expression::Variable(ref bool_var_name, _), ref range) = statements.content()[0] else {
+        let Statement::Expression(ref inner, ref range) = statements.content()[0] else {
             return Vec::new();
         };
-        if let Expression::UnaryCommand(not_cmd, not_rhs, _) = &**left
-            && not_cmd.as_str().eq_ignore_ascii_case("!")
-            && let Expression::UnaryCommand(isnil_cmd, isnil_rhs, _) = &**not_rhs
-            && isnil_cmd.as_str().eq_ignore_ascii_case("isNil")
-            && let Expression::String(isnil_input_str, _, _) = &**isnil_rhs
-            && isnil_input_str.eq_ignore_ascii_case(bool_var_name)
-        {
-            return Vec::new();
-        }
+        let note = match inner {
+            Expression::Variable(bool_var_name, _) => {
+                // `!isNil "z" && {z}` is guarding against z being undefined, the { } is load bearing
+                if let Expression::UnaryCommand(not_cmd, not_rhs, _) = &**left
+                    && not_cmd.as_str().eq_ignore_ascii_case("!")
+                    && let Expression::UnaryCommand(isnil_cmd, isnil_rhs, _) = &**not_rhs
+                    && isnil_cmd.as_str().eq_ignore_ascii_case("isNil")
+                    && let Expression::String(isnil_input_str, _, _) = &**isnil_rhs
+                    && isnil_input_str.eq_ignore_ascii_case(bool_var_name)
+                {
+                    return Vec::new();
+                }
+                "remove the { } and use the variable directly (if safe to do so)"
+            }
+            // a comparison of simple values cannot error, so the short circuit is not guarding it
+            Expression::BinaryCommand(inner_cmd, inner_left, inner_right, _)
+                if is_comparison(inner_cmd)
+                    && is_simple_operand(inner_left)
+                    && is_simple_operand(inner_right) =>
+            {
+                "remove the { } and use the comparison directly, it is cheaper than the short circuit"
+            }
+            _ => return Vec::new(),
+        };
         vec![Arc::new(CodeS26ShortCircuitBoolVar::new(
             range.clone(),
             processed,
             config.severity(),
+            note,
         ))]
     }
 }
@@ -107,6 +168,7 @@ impl LintRunner<LintData> for Runner {
 pub struct CodeS26ShortCircuitBoolVar {
     span: Range<usize>,
     severity: Severity,
+    note: &'static str,
     diagnostic: Option<Diagnostic>,
 }
 
@@ -132,7 +194,7 @@ impl Code for CodeS26ShortCircuitBoolVar {
     }
 
     fn note(&self) -> Option<String> {
-        Some("remove the { } and use the variable directly (if safe to do so)".to_string())
+        Some(self.note.to_string())
     }
 
     fn help(&self) -> Option<String> {
@@ -145,10 +207,16 @@ impl Code for CodeS26ShortCircuitBoolVar {
 }
 impl CodeS26ShortCircuitBoolVar {
     #[must_use]
-    pub fn new(span: Range<usize>, processed: &Processed, severity: Severity) -> Self {
+    pub fn new(
+        span: Range<usize>,
+        processed: &Processed,
+        severity: Severity,
+        note: &'static str,
+    ) -> Self {
         Self {
             span,
             severity,
+            note,
             diagnostic: None,
         }
         .generate_processed(processed)

--- a/libs/sqf/tests/lints/s26_short_circuit_bool_var.sqf
+++ b/libs/sqf/tests/lints/s26_short_circuit_bool_var.sqf
@@ -7,3 +7,26 @@ if (_test1 && {call x; _test2}) then { };
 if (_test1 && {_test2}) then { };
 
 if (!isNil "someVar" && {somevar}) then {}; // ignore
+
+// comparisons of simple values, all reported
+if (_test1 && {_a isEqualTo _b}) then { };
+if (_test1 && {_a isNotEqualTo "text"}) then { };
+if (_test1 && {_a == _b}) then { };
+if (_test1 && {_a != 5}) then { };
+if (_test1 && {_a > 5}) then { };
+if (_test1 && {_a < _b}) then { };
+if (_test1 && {_a >= 5}) then { };
+if (_test1 && {_a <= _b}) then { };
+if (_test1 || {_a isEqualTo _b}) then { };
+if (_test1 && {_a isEqualRef _b}) then { };
+if (_test1 && {_a isNotEqualRef _b}) then { };
+if (_test1 && {_a isEqualType _b}) then { };
+
+// the short circuit is guarding a command, ignore
+if (count _array > 0 && {_array select 0 isEqualTo "x"}) then { };
+if (!isNull _obj && {getPosATL _obj isEqualTo []}) then { };
+if (_test1 && {alive player isEqualTo true}) then { };
+
+// not a comparison, ignore
+if (_test1 && {_a + _b}) then { };
+if (_test1 && {_a isKindOf "Man"}) then { };

--- a/libs/sqf/tests/snapshots/lints__simple_s21_invalid_comparisons.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s21_invalid_comparisons.snap
@@ -1,7 +1,16 @@
 ---
 source: libs/sqf/tests/lints.rs
-expression: lint(stringify! (s21_invalid_comparisons))
+expression: "lint(stringify! (s21_invalid_comparisons), true).0"
 ---
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+  [0m[36m┌─[0m s21_invalid_comparisons.sqf:9:43
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m if ({_y && _x < 10} || {_z && _x > 30 && {[0m[36m_x < 10[0m}}) then {};
+  [0m[36m│[0m                                           [0m[36m^^^^^^^[0m [0m[36munnecessary { }[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
 [0m[1m[38;5;9merror[L-S21][0m[1m: Impossible comparison[0m
   [0m[36m┌─[0m s21_invalid_comparisons.sqf:9:31
   [0m[36m│[0m

--- a/libs/sqf/tests/snapshots/lints__simple_s26_short_circuit_bool_var.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s26_short_circuit_bool_var.snap
@@ -9,3 +9,111 @@ expression: "lint(stringify! (s26_short_circuit_bool_var), true).0"
   [0m[36m│[0m                [0m[36m^^^^^^[0m [0m[36munnecessary { }[0m
   [0m[36m│[0m
   [0m[36m=[0m [36mnote[0m: remove the { } and use the variable directly (if safe to do so)
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:12:16
+   [0m[36m│[0m
+[0m[36m12[0m [0m[36m│[0m if (_test1 && {[0m[36m_a isEqualTo _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:13:16
+   [0m[36m│[0m
+[0m[36m13[0m [0m[36m│[0m if (_test1 && {[0m[36m_a isNotEqualTo "text"[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:14:16
+   [0m[36m│[0m
+[0m[36m14[0m [0m[36m│[0m if (_test1 && {[0m[36m_a == _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:15:16
+   [0m[36m│[0m
+[0m[36m15[0m [0m[36m│[0m if (_test1 && {[0m[36m_a != 5[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:16:16
+   [0m[36m│[0m
+[0m[36m16[0m [0m[36m│[0m if (_test1 && {[0m[36m_a > 5[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:17:16
+   [0m[36m│[0m
+[0m[36m17[0m [0m[36m│[0m if (_test1 && {[0m[36m_a < _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:18:16
+   [0m[36m│[0m
+[0m[36m18[0m [0m[36m│[0m if (_test1 && {[0m[36m_a >= 5[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:19:16
+   [0m[36m│[0m
+[0m[36m19[0m [0m[36m│[0m if (_test1 && {[0m[36m_a <= _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:20:16
+   [0m[36m│[0m
+[0m[36m20[0m [0m[36m│[0m if (_test1 || {[0m[36m_a isEqualTo _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:21:16
+   [0m[36m│[0m
+[0m[36m21[0m [0m[36m│[0m if (_test1 && {[0m[36m_a isEqualRef _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:22:16
+   [0m[36m│[0m
+[0m[36m22[0m [0m[36m│[0m if (_test1 && {[0m[36m_a isNotEqualRef _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+   [0m[36m┌─[0m s26_short_circuit_bool_var.sqf:23:16
+   [0m[36m│[0m
+[0m[36m23[0m [0m[36m│[0m if (_test1 && {[0m[36m_a isEqualType _b[0m}) then { };
+   [0m[36m│[0m                [0m[36m^^^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit


### PR DESCRIPTION
Short circuit evaluation builds and calls a code block, which costs more than the comparison it skips when both sides are simple values. Reports `==`, `!=`, `>`, `<`, `>=`, `<=`, `isEqualTo`, `isNotEqualTo`, `isEqualRef`, `isNotEqualRef` and `isEqualType`.

Only reported when both operands are a variable, number, string or boolean, so a short circuit guarding a command is left alone (createHashmap or comparing against array literals).