### PR TITLE
sqf: S33 - Add `countType` and `countSide`

### DIFF
--- a/libs/sqf/src/analyze/lints/s33_reimplementing_command.rs
+++ b/libs/sqf/src/analyze/lints/s33_reimplementing_command.rs
@@ -7,6 +7,7 @@ mod abs;
 // mod atan2;
 mod ceil;
 mod clamp;
+mod count_type_side;
 mod distance;
 mod floor;
 mod linear_conversion;
@@ -104,6 +105,7 @@ impl LintRunner<LintData> for Runner {
         // https://github.com/acemod/ACE3/pull/6773/files#r250479159
         // codes.extend(atan2::check(target, processed, config));
         codes.extend(ceil::check(target, processed, config));
+        codes.extend(count_type_side::check(target, processed, config));
         codes.extend(distance::check(target, processed, config));
         codes.extend(floor::check(target, processed, config));
         codes.extend(linear_conversion::check(target, processed, config));

--- a/libs/sqf/src/analyze/lints/s33_reimplementing_command/count_type_side.rs
+++ b/libs/sqf/src/analyze/lints/s33_reimplementing_command/count_type_side.rs
@@ -1,0 +1,158 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::reporting::{Code, Diagnostic, Processed, Severity};
+
+use crate::{BinaryCommand, Expression, UnaryCommand};
+
+// Pattern 1: {_x isKindOf TYPE} count ARR  ->  TYPE countType ARR
+// Pattern 2: {side _x == SIDE} count ARR   ->  SIDE countSide ARR
+//
+// Pattern 2 only matches `side _x`. `side group _x` is a different value, a unit's own side
+// can differ from its group's side, so it is deliberately left alone.
+
+pub fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
+    let mut codes = Vec::new();
+
+    let Expression::BinaryCommand(BinaryCommand::Named(cmd), code, array, _) = target else {
+        return codes;
+    };
+    if !cmd.eq_ignore_ascii_case("count") {
+        return codes;
+    }
+    let inner = super::unwrap_code_block(code);
+
+    let found = as_kind_of(inner)
+        .map(|type_expr| ("countType", type_expr))
+        .or_else(|| as_side_comparison(inner).map(|side_expr| ("countSide", side_expr)));
+
+    let Some((command, operand)) = found else {
+        return codes;
+    };
+
+    codes.push(Arc::new(CodeS33ReimplementingCommandCountTypeSide::new(
+        target.full_span(),
+        command,
+        operand.source(true),
+        array.source(true),
+        processed,
+        config.severity(),
+    )) as Arc<dyn Code>);
+    codes
+}
+
+/// Matches `_x isKindOf TYPE`, returning TYPE.
+fn as_kind_of(expr: &Expression) -> Option<&Expression> {
+    let Expression::BinaryCommand(BinaryCommand::Named(name), lhs, rhs, _) = expr else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("isKindOf") {
+        return None;
+    }
+    if !is_x(lhs) {
+        return None;
+    }
+    Some(rhs)
+}
+
+/// Matches `side _x == SIDE` in either operand order, returning SIDE.
+fn as_side_comparison(expr: &Expression) -> Option<&Expression> {
+    let Expression::BinaryCommand(cmd, lhs, rhs, _) = expr else {
+        return None;
+    };
+    let is_eq = matches!(cmd, BinaryCommand::Eq)
+        || matches!(cmd, BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isEqualTo"));
+    if !is_eq {
+        return None;
+    }
+    if is_side_of_x(lhs) {
+        return Some(rhs);
+    }
+    if is_side_of_x(rhs) {
+        return Some(lhs);
+    }
+    None
+}
+
+/// Matches `side _x`, and nothing else. `side group _x` is a different value entirely.
+fn is_side_of_x(expr: &Expression) -> bool {
+    let Expression::UnaryCommand(UnaryCommand::Named(name), inner, _) = expr else {
+        return false;
+    };
+    name.eq_ignore_ascii_case("side") && is_x(inner)
+}
+
+/// The magic variable is spelled exactly `_x`, anything else is a different variable.
+fn is_x(expr: &Expression) -> bool {
+    matches!(expr, Expression::Variable(name, _) if name == "_x")
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS33ReimplementingCommandCountTypeSide {
+    span: Range<usize>,
+    command: &'static str,
+    operand: String,
+    array: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS33ReimplementingCommandCountTypeSide {
+    fn ident(&self) -> &'static str {
+        "L-S33-COUNTTYPESIDE"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#reimplementing_command")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        format!("code can be replaced with `{}`", self.command)
+    }
+
+    fn label_message(&self) -> String {
+        format!("use `{}`", self.command)
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!(
+            "{} {} {}",
+            self.operand, self.command, self.array
+        ))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS33ReimplementingCommandCountTypeSide {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        command: &'static str,
+        operand: String,
+        array: String,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            command,
+            operand,
+            array,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -64,6 +64,7 @@ lint!(s33_abs, true);
 // lint!(s33_atan2, true);
 lint!(s33_ceil, true);
 lint!(s33_clamp, true);
+lint!(s33_count_type_side, true);
 lint!(s33_distance, true);
 lint!(s33_floor, true);
 lint!(s33_linear_conversion, true);

--- a/libs/sqf/tests/lints/s33_count_type_side.sqf
+++ b/libs/sqf/tests/lints/s33_count_type_side.sqf
@@ -1,0 +1,22 @@
+private _units = units player;
+
+// countType, reported
+private _tanks = {_x isKindOf "Tank"} count _units;
+private _medics = {_x isKindOf "B_medic_F"} count allUnits;
+
+// countSide, reported, either operand order
+private _west = {side _x == west} count _units;
+private _east = {east == side _x} count _units;
+private _civ = {side _x isEqualTo civilian} count _units;
+
+// side of the group is not the side of the unit, ignore
+private _grouped = {side group _x == west} count _units;
+private _leader = {side leader _x == west} count _units;
+
+// not the magic _x, ignore
+private _other = {side _y == west} count _units;
+private _kind = {_y isKindOf "Tank"} count _units;
+
+// unrelated counts, ignore
+private _alive = {alive _x} count _units;
+private _plain = count _units;

--- a/libs/sqf/tests/snapshots/lints__simple_s33_count_type_side.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s33_count_type_side.snap
@@ -1,0 +1,47 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s33_count_type_side), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S33-COUNTTYPESIDE][0m[1m: code can be replaced with `countSide`[0m
+  [0m[36m┌─[0m s33_count_type_side.sqf:8:18
+  [0m[36m│[0m
+[0m[36m8[0m [0m[36m│[0m private _west = {[0m[36mside _x == west} count _units[0m;
+  [0m[36m│[0m                  [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countSide`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: west countSide _units
+
+
+[0m[1m[38;5;14mhelp[L-S33-COUNTTYPESIDE][0m[1m: code can be replaced with `countSide`[0m
+  [0m[36m┌─[0m s33_count_type_side.sqf:9:18
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m private _east = {[0m[36meast == side _x} count _units[0m;
+  [0m[36m│[0m                  [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countSide`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: east countSide _units
+
+
+[0m[1m[38;5;14mhelp[L-S33-COUNTTYPESIDE][0m[1m: code can be replaced with `countSide`[0m
+   [0m[36m┌─[0m s33_count_type_side.sqf:10:17
+   [0m[36m│[0m
+[0m[36m10[0m [0m[36m│[0m private _civ = {[0m[36mside _x isEqualTo civilian} count _units[0m;
+   [0m[36m│[0m                 [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countSide`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: civilian countSide _units
+
+
+[0m[1m[38;5;14mhelp[L-S33-COUNTTYPESIDE][0m[1m: code can be replaced with `countType`[0m
+  [0m[36m┌─[0m s33_count_type_side.sqf:4:19
+  [0m[36m│[0m
+[0m[36m4[0m [0m[36m│[0m private _tanks = {[0m[36m_x isKindOf "Tank"} count _units[0m;
+  [0m[36m│[0m                   [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: "Tank" countType _units
+
+
+[0m[1m[38;5;14mhelp[L-S33-COUNTTYPESIDE][0m[1m: code can be replaced with `countType`[0m
+  [0m[36m┌─[0m s33_count_type_side.sqf:5:20
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m private _medics = {[0m[36m_x isKindOf "B_medic_F"} count allUnits[0m;
+  [0m[36m│[0m                    [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: "B_medic_F" countType allUnits


### PR DESCRIPTION
- `{_x isKindOf t} count arr` -> `t countType arr`
- `{side _x == s} count arr` -> `s countSide arr`

Only `side _x` is matched. A unit's own side can differ from its group's, so `side group _x` and `side leader _x` are left alone.