### PR TITLE
sqf: S45 - Use `append` instead of `array = array + [...]`

### DIFF
--- a/libs/sqf/src/analyze/lints/s45_array_append.rs
+++ b/libs/sqf/src/analyze/lints/s45_array_append.rs
@@ -1,0 +1,184 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, Statement, analyze::LintData};
+
+crate::analyze::lint!(LintS45ArrayAppend);
+
+impl Lint<LintData> for LintS45ArrayAppend {
+    fn ident(&self) -> &'static str {
+        "array_append"
+    }
+
+    fn sort(&self) -> u32 {
+        450
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for extending an array with `_array = _array + [...]`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Example
+
+**Incorrect**
+```sqf
+MY_array = MY_array + ["a", "b"];
+```
+**Correct**
+```sqf
+MY_array append ["a", "b"];
+```
+
+### Explanation
+
+`array1 + array2` builds a brand new array and the assignment rebinds the variable to it, so the
+whole array is copied every time it is extended. `append` adds to the existing array in place.
+
+This changes behaviour when something else still holds a reference to the original array, because
+arrays are references and only `+` produces a copy:
+
+```sqf
+private _b = MY_array;
+MY_array = MY_array + ["a"];  // _b keeps the old array, no "a"
+MY_array append ["a"];        // _b sees "a", it is the same array
+```
+
+Only reported when the right hand side is an array literal, so numeric and string `+` are not
+affected."#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = crate::Statement;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        let (assigned, expression, range) = match target {
+            Statement::AssignGlobal(name, expression, range)
+            | Statement::AssignLocal(name, expression, range) => (name, expression, range),
+            Statement::Expression(..) => return Vec::new(),
+        };
+        let Expression::BinaryCommand(BinaryCommand::Add, lhs, rhs, _) = expression else {
+            return Vec::new();
+        };
+        // the variable being assigned has to be the one being added to
+        let Expression::Variable(name, _) = &**lhs else {
+            return Vec::new();
+        };
+        if name != assigned {
+            return Vec::new();
+        }
+        // an array literal is the only right hand side that is certainly an array,
+        // a variable could just as easily be a number or a string
+        if !matches!(
+            &**rhs,
+            Expression::Array(..) | Expression::ConsumeableArray(..)
+        ) {
+            return Vec::new();
+        }
+
+        vec![Arc::new(CodeS45ArrayAppend::new(
+            range.clone(),
+            name.clone(),
+            rhs.source(true),
+            processed,
+            config.severity(),
+        ))]
+    }
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS45ArrayAppend {
+    span: Range<usize>,
+    array: String,
+    value: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS45ArrayAppend {
+    fn ident(&self) -> &'static str {
+        "L-S45"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#array_append")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        "Use `append` instead of `array = array + [...]`".to_string()
+    }
+
+    fn label_message(&self) -> String {
+        "array is copied to extend it".to_string()
+    }
+
+    fn note(&self) -> Option<String> {
+        Some(
+            "`append` extends the array in place, so anything else holding a reference to it will see the new elements"
+                .to_string(),
+        )
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("{} append {}", self.array, self.value))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS45ArrayAppend {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        array: String,
+        value: String,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            array,
+            value,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s45_array_append.rs
+++ b/libs/sqf/src/analyze/lints/s45_array_append.rs
@@ -95,17 +95,23 @@ impl LintRunner<LintData> for Runner {
         }
         // an array literal is the only right hand side that is certainly an array,
         // a variable could just as easily be a number or a string
-        if !matches!(
-            &**rhs,
-            Expression::Array(..) | Expression::ConsumeableArray(..)
-        ) {
+        let (Expression::Array(elements, _) | Expression::ConsumeableArray(elements, _)) = &**rhs
+        else {
             return Vec::new();
-        }
+        };
+
+        // a single element does not need a temporary array built for it
+        let (command, value) = if let [element] = &elements[..] {
+            ("pushBack", element.source(true))
+        } else {
+            ("append", rhs.source(true))
+        };
 
         vec![Arc::new(CodeS45ArrayAppend::new(
             range.clone(),
             name.clone(),
-            rhs.source(true),
+            command,
+            value,
             processed,
             config.severity(),
         ))]
@@ -116,6 +122,7 @@ impl LintRunner<LintData> for Runner {
 pub struct CodeS45ArrayAppend {
     span: Range<usize>,
     array: String,
+    command: &'static str,
     value: String,
     severity: Severity,
     diagnostic: Option<Diagnostic>,
@@ -135,7 +142,7 @@ impl Code for CodeS45ArrayAppend {
     }
 
     fn message(&self) -> String {
-        "Use `append` instead of `array = array + [...]`".to_string()
+        format!("Use `{}` instead of `array = array + [...]`", self.command)
     }
 
     fn label_message(&self) -> String {
@@ -143,14 +150,14 @@ impl Code for CodeS45ArrayAppend {
     }
 
     fn note(&self) -> Option<String> {
-        Some(
-            "`append` extends the array in place, so anything else holding a reference to it will see the new elements"
-                .to_string(),
-        )
+        Some(format!(
+            "`{}` extends the array in place, so anything else holding a reference to it will see the new elements",
+            self.command
+        ))
     }
 
     fn suggestion(&self) -> Option<String> {
-        Some(format!("{} append {}", self.array, self.value))
+        Some(format!("{} {} {}", self.array, self.command, self.value))
     }
 
     fn diagnostic(&self) -> Option<Diagnostic> {
@@ -163,6 +170,7 @@ impl CodeS45ArrayAppend {
     pub fn new(
         span: Range<usize>,
         array: String,
+        command: &'static str,
         value: String,
         processed: &Processed,
         severity: Severity,
@@ -170,6 +178,7 @@ impl CodeS45ArrayAppend {
         Self {
             span,
             array,
+            command,
             value,
             severity,
             diagnostic: None,

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -80,6 +80,7 @@ lint!(s41_foreach_apply, true);
 lint!(s42_for_range, true);
 lint!(s43_array_setcount, true);
 lint!(s44_string_concat_format, true);
+lint!(s45_array_append, true);
 
 #[test]
 fn test_s29_function_undefined() {

--- a/libs/sqf/tests/lints/s45_array_append.sqf
+++ b/libs/sqf/tests/lints/s45_array_append.sqf
@@ -18,3 +18,7 @@ MY_array = MY_array + OTHER_array;
 // not an addition, ignore
 MY_array = [1, 2, 3];
 MY_array append ["a"];
+
+// single element literal should use pushBack, no temporary array needed
+GVAR_gunList = GVAR_gunList + [_gun];
+_local = _local + [_gunProfileEntry];

--- a/libs/sqf/tests/lints/s45_array_append.sqf
+++ b/libs/sqf/tests/lints/s45_array_append.sqf
@@ -1,0 +1,20 @@
+// extending an array with a literal, reported
+WMO_noRoadway = WMO_noRoadway + ["NonSteerable_Parachute_F", "RopeSegment"];
+
+private _local = [1, 2];
+_local = _local + [3];
+
+// a different variable on the right, ignore
+MY_array = OTHER_array + ["a"];
+
+// prepending is not append, ignore
+MY_array = ["a"] + MY_array;
+
+// right hand side is not an array literal, could be a number or string, ignore
+_total = _total + _delta;
+_text = _text + "more";
+MY_array = MY_array + OTHER_array;
+
+// not an addition, ignore
+MY_array = [1, 2, 3];
+MY_array append ["a"];

--- a/libs/sqf/tests/snapshots/lints__simple_s45_array_append.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s45_array_append.snap
@@ -12,11 +12,31 @@ expression: "lint(stringify! (s45_array_append), true).0"
   [0m[36m=[0m [32mtry[0m: WMO_noRoadway append ["NonSteerable_Parachute_F","RopeSegment"]
 
 
-[0m[1m[38;5;14mhelp[L-S45][0m[1m: Use `append` instead of `array = array + [...]`[0m
+[0m[1m[38;5;14mhelp[L-S45][0m[1m: Use `pushBack` instead of `array = array + [...]`[0m
   [0m[36m┌─[0m s45_array_append.sqf:5:1
   [0m[36m│[0m
 [0m[36m5[0m [0m[36m│[0m [0m[36m_local = _local + [3][0m;
   [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray is copied to extend it[0m
   [0m[36m│[0m
-  [0m[36m=[0m [36mnote[0m: `append` extends the array in place, so anything else holding a reference to it will see the new elements
-  [0m[36m=[0m [32mtry[0m: _local append [3]
+  [0m[36m=[0m [36mnote[0m: `pushBack` extends the array in place, so anything else holding a reference to it will see the new elements
+  [0m[36m=[0m [32mtry[0m: _local pushBack 3
+
+
+[0m[1m[38;5;14mhelp[L-S45][0m[1m: Use `pushBack` instead of `array = array + [...]`[0m
+   [0m[36m┌─[0m s45_array_append.sqf:23:1
+   [0m[36m│[0m
+[0m[36m23[0m [0m[36m│[0m [0m[36mGVAR_gunList = GVAR_gunList + [_gun][0m;
+   [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray is copied to extend it[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `pushBack` extends the array in place, so anything else holding a reference to it will see the new elements
+   [0m[36m=[0m [32mtry[0m: GVAR_gunList pushBack _gun
+
+
+[0m[1m[38;5;14mhelp[L-S45][0m[1m: Use `pushBack` instead of `array = array + [...]`[0m
+   [0m[36m┌─[0m s45_array_append.sqf:24:1
+   [0m[36m│[0m
+[0m[36m24[0m [0m[36m│[0m [0m[36m_local = _local + [_gunProfileEntry][0m;
+   [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray is copied to extend it[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `pushBack` extends the array in place, so anything else holding a reference to it will see the new elements
+   [0m[36m=[0m [32mtry[0m: _local pushBack _gunProfileEntry

--- a/libs/sqf/tests/snapshots/lints__simple_s45_array_append.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s45_array_append.snap
@@ -1,0 +1,22 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s45_array_append), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S45][0m[1m: Use `append` instead of `array = array + [...]`[0m
+  [0m[36m┌─[0m s45_array_append.sqf:2:1
+  [0m[36m│[0m
+[0m[36m2[0m [0m[36m│[0m [0m[36mWMO_noRoadway = WMO_noRoadway + ["NonSteerable_Parachute_F", "RopeSegment"][0m;
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray is copied to extend it[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `append` extends the array in place, so anything else holding a reference to it will see the new elements
+  [0m[36m=[0m [32mtry[0m: WMO_noRoadway append ["NonSteerable_Parachute_F","RopeSegment"]
+
+
+[0m[1m[38;5;14mhelp[L-S45][0m[1m: Use `append` instead of `array = array + [...]`[0m
+  [0m[36m┌─[0m s45_array_append.sqf:5:1
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m [0m[36m_local = _local + [3][0m;
+  [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^[0m [0m[36marray is copied to extend it[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `append` extends the array in place, so anything else holding a reference to it will see the new elements
+  [0m[36m=[0m [32mtry[0m: _local append [3]


### PR DESCRIPTION
`array1 + array2` builds a new array and the assignment rebinds the variable to it, copying the whole array every time it is extended. `append` extends the existing array in place.

Only reported when the right hand side is an array literal, so numeric and string `+` are unaffected. The finding notes that `append` mutates in place, which is visible to anything else holding a reference.

caught in ACE:
<img width="970" height="379" alt="image" src="https://github.com/user-attachments/assets/59c62fd3-d79d-4a8a-b1b7-63ca3733940b" />
