### PR TITLE
sqf: S33 - Add `pushBackUnique`

### DIFF
--- a/libs/sqf/src/analyze/lints/s33_reimplementing_command.rs
+++ b/libs/sqf/src/analyze/lints/s33_reimplementing_command.rs
@@ -14,6 +14,7 @@ mod max;
 mod min;
 mod modulo;
 mod pi;
+mod push_back_unique;
 crate::analyze::lint!(LintS33ReimplementingCommand);
 
 /// Check if two expressions match, considering variables and optionally unwrapping code blocks
@@ -111,6 +112,7 @@ impl LintRunner<LintData> for Runner {
         codes.extend(min::check(target, processed, config));
         codes.extend(modulo::check(target, processed, config));
         codes.extend(pi::check(target, processed, config));
+        codes.extend(push_back_unique::check(target, processed, config));
         codes
     }
 }

--- a/libs/sqf/src/analyze/lints/s33_reimplementing_command/push_back_unique.rs
+++ b/libs/sqf/src/analyze/lints/s33_reimplementing_command/push_back_unique.rs
@@ -1,0 +1,176 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::reporting::{Code, Diagnostic, Processed, Severity};
+
+use crate::{BinaryCommand, Expression, Statement, UnaryCommand};
+
+// Pattern 1: if !(x in arr) then {arr pushBack x}        -> arr pushBackUnique x
+// Pattern 2: if !(x in arr) then {arr pushBackUnique x}  -> the check is already done by the command
+//
+// `in` and `pushBackUnique` are both case sensitive on strings, so the two are equivalent.
+
+pub fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
+    let mut codes = Vec::new();
+
+    // if ... then {...}, with no else branch
+    let Expression::BinaryCommand(BinaryCommand::Named(then_cmd), if_expr, code, _) = target else {
+        return codes;
+    };
+    if !then_cmd.eq_ignore_ascii_case("then") {
+        return codes;
+    }
+    let Expression::UnaryCommand(UnaryCommand::Named(if_cmd), condition, _) = &**if_expr else {
+        return codes;
+    };
+    if !if_cmd.eq_ignore_ascii_case("if") {
+        return codes;
+    }
+
+    let Some((needle, haystack)) = as_negated_in(condition) else {
+        return codes;
+    };
+    let Some((array, value, already_unique)) = as_push(code) else {
+        return codes;
+    };
+
+    // the array searched has to be the array pushed to, and the value likewise
+    if !super::expressions_match(haystack, array, false)
+        || !super::expressions_match(needle, value, false)
+    {
+        return codes;
+    }
+
+    codes.push(Arc::new(CodeS33ReimplementingCommandPushBackUnique::new(
+        target.full_span(),
+        array.source(true),
+        value.source(true),
+        already_unique,
+        processed,
+        config.severity(),
+    )) as Arc<dyn Code>);
+    codes
+}
+
+/// Matches `!(x in arr)`, returning the needle and the haystack.
+fn as_negated_in(expr: &Expression) -> Option<(&Expression, &Expression)> {
+    let Expression::UnaryCommand(UnaryCommand::Not, inner, _) = expr else {
+        return None;
+    };
+    let Expression::BinaryCommand(BinaryCommand::Named(name), needle, haystack, _) = &**inner
+    else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("in") {
+        return None;
+    }
+    Some((needle, haystack))
+}
+
+/// Matches a lone `arr pushBack x` or `arr pushBackUnique x` in the then branch.
+/// The bool is true when it is already `pushBackUnique`, so the guard is simply redundant.
+fn as_push(expr: &Expression) -> Option<(&Expression, &Expression, bool)> {
+    let Expression::Code(statements) = expr else {
+        return None;
+    };
+    // anything else in the branch means the guard is doing more than the command would
+    if statements.content().len() != 1 {
+        return None;
+    }
+    let Statement::Expression(Expression::BinaryCommand(BinaryCommand::Named(name), array, value, _), _) =
+        &statements.content()[0]
+    else {
+        return None;
+    };
+    if name.eq_ignore_ascii_case("pushBack") {
+        return Some((array, value, false));
+    }
+    if name.eq_ignore_ascii_case("pushBackUnique") {
+        return Some((array, value, true));
+    }
+    None
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS33ReimplementingCommandPushBackUnique {
+    span: Range<usize>,
+    array: String,
+    value: String,
+    already_unique: bool,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS33ReimplementingCommandPushBackUnique {
+    fn ident(&self) -> &'static str {
+        "L-S33-PUSHBACKUNIQUE"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#reimplementing_command")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        if self.already_unique {
+            String::from("`pushBackUnique` already checks this")
+        } else {
+            String::from("code can be replaced with `pushBackUnique`")
+        }
+    }
+
+    fn label_message(&self) -> String {
+        if self.already_unique {
+            String::from("redundant check")
+        } else {
+            String::from("use `pushBackUnique`")
+        }
+    }
+
+    fn note(&self) -> Option<String> {
+        if self.already_unique {
+            return Some(String::from(
+                "`pushBackUnique` only adds the element if it is not already in the array",
+            ));
+        }
+        None
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("{} pushBackUnique {}", self.array, self.value))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS33ReimplementingCommandPushBackUnique {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        array: String,
+        value: String,
+        already_unique: bool,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            array,
+            value,
+            already_unique,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -71,6 +71,7 @@ lint!(s33_max, true);
 lint!(s33_min, true);
 lint!(s33_mod, true);
 lint!(s33_pi, true);
+lint!(s33_push_back_unique, true);
 lint!(s35_count_skipable, true);
 lint!(s36_global_var_in_local, true);
 lint!(s38_direct_private, true);

--- a/libs/sqf/tests/lints/s33_push_back_unique.sqf
+++ b/libs/sqf/tests/lints/s33_push_back_unique.sqf
@@ -1,0 +1,26 @@
+private _addons = [];
+private _paramAddons = ["a", "b"];
+
+// the ACE3 pattern this came from, both reported
+{
+    if !(_x in _addons) then {_addons pushBack _x};
+    if !(_x in _addons) then {_addons pushBackUnique _x};
+} forEach _paramAddons;
+
+// plain variables, reported
+if !(_value in _list) then {_list pushBack _value};
+
+// searched array is not the pushed array, ignore
+if !(_value in _list) then {_other pushBack _value};
+
+// pushed value is not the searched value, ignore
+if !(_value in _list) then {_list pushBack _somethingElse};
+
+// branch does more than push, the guard is not redundant, ignore
+if !(_value in _list) then {_list pushBack _value; _count = _count + 1};
+
+// not negated, ignore
+if (_value in _list) then {_list pushBack _value};
+
+// has an else branch, ignore
+if !(_value in _list) then {_list pushBack _value} else {_list pushBack 0};

--- a/libs/sqf/tests/snapshots/lints__simple_s33_push_back_unique.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s33_push_back_unique.snap
@@ -1,0 +1,46 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s33_push_back_unique), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S11][0m[1m: Unneeded not in if[0m
+   [0m[36m┌─[0m s33_push_back_unique.sqf:26:4
+   [0m[36m│[0m
+[0m[36m26[0m [0m[36m│[0m if [0m[36m![0m(_value in _list) then {_list pushBack _value} else {_list pushBack 0};
+   [0m[36m│[0m    [0m[36m^[0m [0m[36munnecessary `!` operation[0m
+
+
+[0m[1m[38;5;14mhelp[L-S33-PUSHBACKUNIQUE][0m[1m: `pushBackUnique` already checks this[0m
+  [0m[36m┌─[0m s33_push_back_unique.sqf:7:5
+  [0m[36m│[0m
+[0m[36m7[0m [0m[36m│[0m     [0m[36mif !(_x in _addons) then {_addons pushBackUnique _x[0m};
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mredundant check[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `pushBackUnique` only adds the element if it is not already in the array
+  [0m[36m=[0m [32mtry[0m: _addons pushBackUnique _x
+
+
+[0m[1m[38;5;14mhelp[L-S33-PUSHBACKUNIQUE][0m[1m: code can be replaced with `pushBackUnique`[0m
+  [0m[36m┌─[0m s33_push_back_unique.sqf:6:5
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m     [0m[36mif !(_x in _addons) then {_addons pushBack _x[0m};
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `pushBackUnique`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _addons pushBackUnique _x
+
+
+[0m[1m[38;5;14mhelp[L-S33-PUSHBACKUNIQUE][0m[1m: code can be replaced with `pushBackUnique`[0m
+   [0m[36m┌─[0m s33_push_back_unique.sqf:11:1
+   [0m[36m│[0m
+[0m[36m11[0m [0m[36m│[0m [0m[36mif !(_value in _list) then {_list pushBack _value[0m};
+   [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `pushBackUnique`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: _list pushBackUnique _value
+
+
+[0m[1m[38;5;14mhelp[L-S41][0m[1m: Use `apply` instead of `forEach` when `_forEachIndex` is unused[0m
+  [0m[36m┌─[0m s33_push_back_unique.sqf:8:3
+  [0m[36m│[0m
+[0m[36m8[0m [0m[36m│[0m } [0m[36mforEach[0m _paramAddons;
+  [0m[36m│[0m   [0m[36m^^^^^^^[0m [0m[36mforEach loop can use apply[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [33mhelp[0m: replace with `array apply { ... }`


### PR DESCRIPTION
- `if !(x in arr) then {arr pushBack x}` -> `arr pushBackUnique x`
- the same shape already using `pushBackUnique` is reported as a redundant check, since the command does it

`in` and `pushBackUnique` are both case sensitive on strings, so the rewrite is exact. Only reported when the searched array is the array pushed to, the value matches, and the branch does nothing else.