### PR TITLE
lints: Report unused/misnamed lint configs

### DIFF
--- a/libs/config/src/analyze/mod.rs
+++ b/libs/config/src/analyze/mod.rs
@@ -214,8 +214,8 @@ pub fn lint_all(project: Option<&ProjectConfig>, addons: &Vec<Addon>) -> Codes {
             .map(|l| (**l).clone())
             .collect::<Vec<_>>(),
     );
-
-    manager.run(
+    let mut codes = manager.check_config_usage("config", "c");
+    codes.extend(manager.run(
         &LintData {
             path: String::new(),
             localizations: Arc::new(Mutex::new(vec![])),
@@ -225,5 +225,6 @@ pub fn lint_all(project: Option<&ProjectConfig>, addons: &Vec<Addon>) -> Codes {
         project,
         None,
         addons,
-    )
+    ));
+    codes
 }

--- a/libs/sqf/src/analyze/mod.rs
+++ b/libs/sqf/src/analyze/mod.rs
@@ -72,7 +72,8 @@ pub fn analyze(
     let localizations = Arc::new(Mutex::new(vec![]));
     let functions_used = Arc::new(Mutex::new(vec![]));
     let functions_defined = Arc::new(Mutex::new(HashSet::new()));
-    let codes = statements.analyze(
+    let mut codes = manager.check_config_usage("sqf", "s");
+    codes.extend(statements.analyze(
         &LintData {
             addon: Some(addon),
             database,
@@ -83,7 +84,7 @@ pub fn analyze(
         project,
         processed,
         &manager,
-    );
+    ));
 
     let localizations = Arc::<Mutex<Localizations>>::try_unwrap(localizations)
         .expect("not poisoned")

--- a/libs/stringtable/src/analyze/mod.rs
+++ b/libs/stringtable/src/analyze/mod.rs
@@ -57,5 +57,7 @@ pub fn lint_all(
     ) {
         return e;
     }
-    manager.run(&LintData { addons }, project_config, None, projects)
+    let mut codes = manager.check_config_usage("stringtable", "l");
+    codes.extend(manager.run(&LintData { addons }, project_config, None, projects));
+    codes
 }

--- a/libs/workspace/src/lint/mod.rs
+++ b/libs/workspace/src/lint/mod.rs
@@ -1,6 +1,9 @@
 pub mod macros;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex, OnceLock},
+};
 
 use codespan_reporting::diagnostic::Severity;
 use hemtt_common::config::{
@@ -124,12 +127,14 @@ impl<T: LintGroupRunner<D>, D> AnyLintGroupRunner<D> for T {
 }
 
 pub type Lints<D> = Vec<Arc<Box<dyn Lint<D>>>>;
+static LINTS_CHECKED_FOR_UNUSED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 #[allow(clippy::module_name_repetitions)]
 pub struct LintManager<D> {
     lints: Lints<D>,
     groups: Vec<(Lints<D>, Box<dyn AnyLintGroupRunner<D>>)>,
     configs: HashMap<String, LintConfigOverride>,
+    used_configs: HashSet<String>,
     runtime: RuntimeArguments,
 }
 
@@ -140,6 +145,7 @@ impl<D> LintManager<D> {
             lints: vec![],
             groups: vec![],
             configs,
+            used_configs: HashSet::new(),
             runtime,
         }
     }
@@ -183,7 +189,7 @@ impl<D> LintManager<D> {
     ///
     /// # Errors
     /// Returns a list of lints that are enabled OR codes if the lint config is invalid
-    pub fn check_and_filter(&self, lints: Lints<D>) -> Result<Lints<D>, Codes> {
+    pub fn check_and_filter(&mut self, lints: Lints<D>) -> Result<Lints<D>, Codes> {
         fn enabled(config: &LintConfig, runtime: &RuntimeArguments) -> bool {
             config.enabled() == LintEnabled::Enabled
                 || (runtime.is_pedantic() && config.enabled() == LintEnabled::Pedantic)
@@ -198,6 +204,7 @@ impl<D> LintManager<D> {
             }
             let mut config = lint.default_config();
             if let Some(config_override) = self.configs.get(lint.ident()) {
+                self.used_configs.insert(lint.ident().to_string());
                 config = config_override.apply(config);
                 if config.severity() < lint.minimum_severity() {
                     errors.push(Arc::new(InvalidLintConfig {
@@ -264,6 +271,44 @@ impl<D> LintManager<D> {
             }))
             .collect()
     }
+
+    #[must_use]
+    /// Checks configured lints and reports entries that are unused.
+    /// # Panics
+    pub fn check_config_usage(&self, lint_name: &str, lint_prefix: &str) -> Codes {
+        if !LINTS_CHECKED_FOR_UNUSED
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .expect("can lock")
+            .insert(lint_name.to_string())
+        {
+            return vec![];
+        }
+        self.configs
+            .keys()
+            .filter(|config| !self.used_configs.contains(*config))
+            .map(|config| {
+                let possible = self.lints.iter().find_map(|lint| {
+                    if config.eq_ignore_ascii_case(
+                        format!("{}{:02}", lint_prefix, lint.sort() / 10).as_str(),
+                    ) || config.eq_ignore_ascii_case(
+                        format!("L-{}{:02}", lint_prefix, lint.sort() / 10).as_str(),
+                    ) || config.eq_ignore_ascii_case(format!("{:02}", lint.sort() / 10).as_str())
+                    {
+                        Some(format!("Did you mean `{lint_name}.{}`?", lint.ident()))
+                    } else {
+                        None
+                    }
+                });
+                Arc::new(UnusedLintConfig {
+                    message: format!(
+                        "Lint config `{lint_name}.{config}` does not exist and has no effect"
+                    ),
+                    possible,
+                }) as Arc<dyn Code>
+            })
+            .collect()
+    }
 }
 
 struct InvalidLintConfig {
@@ -280,6 +325,28 @@ impl Code for InvalidLintConfig {
 
     fn diagnostic(&self) -> Option<Diagnostic> {
         Some(Diagnostic::from_code(self))
+    }
+}
+
+struct UnusedLintConfig {
+    message: String,
+    possible: Option<String>,
+}
+impl Code for UnusedLintConfig {
+    fn ident(&self) -> &'static str {
+        "ULC"
+    }
+    fn message(&self) -> String {
+        self.message.clone()
+    }
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        Some(Diagnostic::from_code(self))
+    }
+    fn severity(&self) -> Severity {
+        Severity::Warning
+    }
+    fn help(&self) -> Option<String> {
+        self.possible.clone()
     }
 }
 
@@ -423,6 +490,7 @@ mod tests {
             lints: vec![Arc::new(Box::new(LintA)), Arc::new(Box::new(LintB))],
             groups: vec![],
             configs: HashMap::new(),
+            used_configs: HashSet::new(),
             runtime: RuntimeArguments::default(),
         };
 


### PR DESCRIPTION
```
[sqf.12]
enabled = false
[config.c09]
enabled = true
```
```
warning[ULC]: Lint config `sqf.12` does not exist and has no effect
 = help: Did you mean `sqf.unused`?
warning[ULC]: Lint config `config.c09` does not exist and has no effect
 = help: Did you mean `config.magwell_missing_magazine`?
```
