### PR TITLE
sqf: Add S46-S51, command replacement lints

### DIFF
--- a/bin/src/utils/config/inspect.rs
+++ b/bin/src/utils/config/inspect.rs
@@ -44,7 +44,6 @@ pub fn inspect(file: &PathBuf) -> Result<(), Error> {
                     eprintln!("{}", diag.to_string(&workspacefiles));
                 }
             }
-            Ok(())
         }
         Err(errors) => {
             for error in errors {
@@ -52,9 +51,9 @@ pub fn inspect(file: &PathBuf) -> Result<(), Error> {
                     eprintln!("{}", diag.to_string(&workspacefiles));
                 }
             }
-            Ok(())
         }
     }
+    Ok(())
 }
 
 pub fn get_report(file: &PathBuf) -> Result<Result<ConfigReport, Vec<Arc<dyn Code>>>, Error> {

--- a/libs/sqf/src/analyze/lints/s46_is_equal_type.rs
+++ b/libs/sqf/src/analyze/lints/s46_is_equal_type.rs
@@ -1,0 +1,187 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, UnaryCommand, analyze::LintData};
+
+crate::analyze::lint!(LintS46IsEqualType);
+
+impl Lint<LintData> for LintS46IsEqualType {
+    fn ident(&self) -> &'static str {
+        "is_equal_type"
+    }
+
+    fn sort(&self) -> u32 {
+        460
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for comparing two `typeName` results, which can be replaced with `isEqualType`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+if (typeName _a == typeName _b) then {};
+```
+**Correct**
+```sqf
+if (_a isEqualType _b) then {};
+```
+
+### Explanation
+
+`isEqualType` compares the types of two values directly. Comparing `typeName` results instead
+builds a string for each side and then compares those strings, which is slower.
+
+See also `static_typename`, which covers `typeName` used on a constant value."
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        check(target, processed, config)
+    }
+}
+
+// Pattern: typeName A == typeName B  ->  A isEqualType B
+// The negated form maps to !(A isEqualType B).
+// Comparing typeName results builds a string per side, isEqualType compares the types directly.
+
+fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
+    let mut codes = Vec::new();
+
+    let Expression::BinaryCommand(cmd, left, right, _) = target else {
+        return codes;
+    };
+    let negated = match cmd {
+        BinaryCommand::Eq => false,
+        BinaryCommand::NotEq => true,
+        BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isEqualTo") => false,
+        BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isNotEqualTo") => true,
+        _ => return codes,
+    };
+    let (Some(lhs), Some(rhs)) = (as_typename(left), as_typename(right)) else {
+        return codes;
+    };
+
+    codes.push(Arc::new(CodeS46IsEqualType::new(
+        target.full_span(),
+        lhs.source(true),
+        rhs.source(true),
+        negated,
+        processed,
+        config.severity(),
+    )) as Arc<dyn Code>);
+    codes
+}
+
+/// Matches `typeName X`, returning X.
+fn as_typename(expr: &Expression) -> Option<&Expression> {
+    let Expression::UnaryCommand(UnaryCommand::Named(name), inner, _) = expr else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("typeName") {
+        return None;
+    }
+    Some(inner)
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS46IsEqualType {
+    span: Range<usize>,
+    left: String,
+    right: String,
+    negated: bool,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS46IsEqualType {
+    fn ident(&self) -> &'static str {
+        "L-S46"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#is_equal_type")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        String::from("code can be replaced with `isEqualType`")
+    }
+
+    fn label_message(&self) -> String {
+        String::from("use `isEqualType`")
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(if self.negated {
+            format!("!({} isEqualType {})", self.left, self.right)
+        } else {
+            format!("{} isEqualType {}", self.left, self.right)
+        })
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS46IsEqualType {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        left: String,
+        right: String,
+        negated: bool,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            left,
+            right,
+            negated,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s47_is_equal_type_any.rs
+++ b/libs/sqf/src/analyze/lints/s47_is_equal_type_any.rs
@@ -52,7 +52,7 @@ separate comparison for each."#
 
 struct Runner;
 impl LintRunner<LintData> for Runner {
-    type Target = Expression;
+    type Target = crate::Statement;
 
     fn run(
         &self,
@@ -66,7 +66,61 @@ impl LintRunner<LintData> for Runner {
         let Some(processed) = processed else {
             return Vec::new();
         };
-        check(target, processed, config)
+
+        // Walking from the statement, rather than being handed every expression, is what lets
+        // this see whether an `||` has another `||` above it. `a || b || c` parses as
+        // `(a || b) || c`, so only the outermost node has the whole chain beneath it.
+        let mut codes = Vec::new();
+        let expression = match target {
+            crate::Statement::AssignGlobal(_, expression, _)
+            | crate::Statement::AssignLocal(_, expression, _)
+            | crate::Statement::Expression(expression, _) => expression,
+        };
+        walk(expression, false, processed, config, &mut codes);
+        codes
+    }
+}
+
+/// Visits every expression, reporting a chain only at its outermost `||`.
+fn walk(
+    expression: &Expression,
+    parent_is_or: bool,
+    processed: &Processed,
+    config: &LintConfig,
+    codes: &mut Codes,
+) {
+    if let Expression::BinaryCommand(BinaryCommand::Or, ..) = expression
+        && !parent_is_or
+    {
+        codes.extend(check(expression, processed, config));
+    }
+
+    let is_or = matches!(expression, Expression::BinaryCommand(BinaryCommand::Or, ..));
+
+    match expression {
+        Expression::BinaryCommand(_, lhs, rhs, _) => {
+            walk(lhs, is_or, processed, config, codes);
+            walk(rhs, is_or, processed, config, codes);
+        }
+        Expression::UnaryCommand(_, inner, _) => {
+            walk(inner, false, processed, config, codes);
+        }
+        Expression::Array(items, _) | Expression::ConsumeableArray(items, _) => {
+            for item in items {
+                walk(item, false, processed, config, codes);
+            }
+        }
+        Expression::Code(statements) => {
+            for statement in statements.content() {
+                let inner = match statement {
+                    crate::Statement::AssignGlobal(_, inner, _)
+                    | crate::Statement::AssignLocal(_, inner, _)
+                    | crate::Statement::Expression(inner, _) => inner,
+                };
+                walk(inner, false, processed, config, codes);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -76,15 +130,9 @@ impl LintRunner<LintData> for Runner {
 fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
     let mut codes = Vec::new();
 
-    let Expression::BinaryCommand(BinaryCommand::Or, left, _, _) = target else {
+    let Expression::BinaryCommand(BinaryCommand::Or, ..) = target else {
         return codes;
     };
-    // `a || b || c` parses as `(a || b) || c`, and every `||` in the chain is visited.
-    // Only the innermost is reported, so a chain produces one finding rather than one per link.
-    if matches!(**left, Expression::BinaryCommand(BinaryCommand::Or, ..)) {
-        return codes;
-    }
-
     let mut branches = Vec::new();
     if !flatten_or(target, &mut branches) {
         return codes;

--- a/libs/sqf/src/analyze/lints/s47_is_equal_type_any.rs
+++ b/libs/sqf/src/analyze/lints/s47_is_equal_type_any.rs
@@ -1,0 +1,233 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, analyze::LintData};
+
+crate::analyze::lint!(LintS47IsEqualTypeAny);
+
+impl Lint<LintData> for LintS47IsEqualTypeAny {
+    fn ident(&self) -> &'static str {
+        "is_equal_type_any"
+    }
+
+    fn sort(&self) -> u32 {
+        470
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for chained `isEqualType` comparisons, which can be replaced with `isEqualTypeAny`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Example
+
+**Incorrect**
+```sqf
+if (_x isEqualType 0 || _x isEqualType "") then {};
+```
+**Correct**
+```sqf
+if (_x isEqualTypeAny [0, ""]) then {};
+```
+
+### Explanation
+
+`isEqualTypeAny` compares a value against several types in one command, rather than chaining a
+separate comparison for each."#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        check(target, processed, config)
+    }
+}
+
+// Pattern: x isEqualType a || x isEqualType b || ...
+// SQF Structure: (binary ||) of two or more `isEqualType` comparisons sharing a left hand side
+
+fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
+    let mut codes = Vec::new();
+
+    let Expression::BinaryCommand(BinaryCommand::Or, left, _, _) = target else {
+        return codes;
+    };
+    // `a || b || c` parses as `(a || b) || c`, and every `||` in the chain is visited.
+    // Only the innermost is reported, so a chain produces one finding rather than one per link.
+    if matches!(**left, Expression::BinaryCommand(BinaryCommand::Or, ..)) {
+        return codes;
+    }
+
+    let mut branches = Vec::new();
+    if !flatten_or(target, &mut branches) {
+        return codes;
+    }
+
+    // every branch must be `x isEqualType <type>` with the same x
+    let mut types = Vec::new();
+    let mut value: Option<&Expression> = None;
+    for branch in branches {
+        let Some((lhs, rhs)) = as_is_equal_type(branch) else {
+            return codes;
+        };
+        match value {
+            None => value = Some(lhs),
+            Some(previous) if expressions_match(previous, lhs) => {}
+            Some(_) => return codes,
+        }
+        types.push(rhs.source(true));
+    }
+
+    let Some(value) = value else {
+        return codes;
+    };
+    if types.len() < 2 {
+        return codes;
+    }
+
+    codes.push(Arc::new(CodeS47IsEqualTypeAny::new(
+        target.full_span(),
+        value.source(true),
+        types,
+        processed,
+        config.severity(),
+    )) as Arc<dyn Code>);
+    codes
+}
+
+/// Flattens a chain of `||` into its branches. Returns false if a branch is itself unusable.
+fn flatten_or<'a>(expr: &'a Expression, out: &mut Vec<&'a Expression>) -> bool {
+    if let Expression::BinaryCommand(BinaryCommand::Or, left, right, _) = expr {
+        return flatten_or(left, out) && flatten_or(right, out);
+    }
+    out.push(expr);
+    true
+}
+
+/// Matches `x isEqualType y`, seeing through a short circuit code block on the right of `||`.
+fn as_is_equal_type(expr: &Expression) -> Option<(&Expression, &Expression)> {
+    let expr = unwrap_code_block(expr);
+    let Expression::BinaryCommand(BinaryCommand::Named(name), lhs, rhs, _) = expr else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("isEqualType") {
+        return None;
+    }
+    Some((lhs, rhs))
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS47IsEqualTypeAny {
+    span: Range<usize>,
+    value: String,
+    types: Vec<String>,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS47IsEqualTypeAny {
+    fn ident(&self) -> &'static str {
+        "L-S47"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#is_equal_type_any")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        String::from("code can be replaced with `isEqualTypeAny`")
+    }
+
+    fn label_message(&self) -> String {
+        String::from("use `isEqualTypeAny`")
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!(
+            "{} isEqualTypeAny [{}]",
+            self.value,
+            self.types.join(", ")
+        ))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS47IsEqualTypeAny {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        value: String,
+        types: Vec<String>,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            value,
+            types,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}
+
+/// Check if two expressions match, considering variables and numbers
+fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
+    match (expr1, expr2) {
+        (Expression::Variable(v1, _), Expression::Variable(v2, _)) => v1 == v2,
+        (Expression::Number(n1, _), Expression::Number(n2, _)) => {
+            (n1.0 - n2.0).abs() < f32::EPSILON
+        }
+        _ => false,
+    }
+}
+
+/// Unwrap a code block to get the inner expression
+fn unwrap_code_block(expr: &Expression) -> &Expression {
+    if let Expression::Code(statements) = expr
+        && let Some(crate::Statement::Expression(inner, _)) = statements.content().first()
+    {
+        return inner;
+    }
+    expr
+}

--- a/libs/sqf/src/analyze/lints/s48_is_equal_type_all.rs
+++ b/libs/sqf/src/analyze/lints/s48_is_equal_type_all.rs
@@ -1,0 +1,353 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, UnaryCommand, analyze::LintData};
+
+crate::analyze::lint!(LintS48IsEqualTypeAll);
+
+impl Lint<LintData> for LintS48IsEqualTypeAll {
+    fn ident(&self) -> &'static str {
+        "is_equal_type_all"
+    }
+
+    fn sort(&self) -> u32 {
+        480
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for verifying the type of every array element, replaceable with `isEqualTypeAll`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+if ({_x isEqualType 0} count _arr == count _arr) then {};
+if (_arr findIf {!(_x isEqualType 0)} == -1) then {};
+```
+**Correct**
+```sqf
+if (_arr isEqualTypeAll 0) then {};
+```
+
+### Explanation
+
+`isEqualTypeAll` checks the type of every element in one command.
+
+Note that `isEqualTypeAll` returns `false` for an empty array, where the checks above return
+`true`, so the replacement is not equivalent for an array that may be empty."
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        check(target, processed, config)
+    }
+}
+
+// Pattern 1: {_x isEqualType T} count ARR == count ARR
+// Pattern 2: ARR findIf {!(_x isEqualType T)} == -1
+// Both are `ARR isEqualTypeAll T`, except on an empty array, see the note on the emitted code.
+// The negated forms (`!=`, `> -1`, `>= 0`, ...) map to `!(ARR isEqualTypeAll T)`.
+
+fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
+    let mut codes = Vec::new();
+
+    let Expression::BinaryCommand(cmd, left, right, _) = target else {
+        return codes;
+    };
+
+    let Some((array, type_expr, negated)) =
+        check_count(cmd, left, right).or_else(|| check_findif(cmd, left, right))
+    else {
+        return codes;
+    };
+
+    codes.push(Arc::new(CodeS48IsEqualTypeAll::new(
+        target.full_span(),
+        array.source(true),
+        type_expr.source(true),
+        negated,
+        processed,
+        config.severity(),
+    )) as Arc<dyn Code>);
+    codes
+}
+
+/// `{_x isEqualType T} count ARR == count ARR`, in either operand order.
+fn check_count<'a>(
+    cmd: &BinaryCommand,
+    left: &'a Expression,
+    right: &'a Expression,
+) -> Option<(&'a Expression, &'a Expression, bool)> {
+    let negated = equality_polarity(cmd)?;
+    let (array, type_expr) =
+        count_sides(left, right).or_else(|| count_sides(right, left))?;
+    Some((array, type_expr, negated))
+}
+
+/// Matches `{_x isEqualType T} count ARR` against `count ARR` over the same array.
+fn count_sides<'a>(
+    counted: &'a Expression,
+    total: &'a Expression,
+) -> Option<(&'a Expression, &'a Expression)> {
+    let Expression::BinaryCommand(BinaryCommand::Named(name), code, array, _) = counted else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("count") {
+        return None;
+    }
+    let type_expr = as_x_is_equal_type(unwrap_code_block(code), false)?;
+
+    let Expression::UnaryCommand(UnaryCommand::Named(total_name), total_array, _) = total else {
+        return None;
+    };
+    if !total_name.eq_ignore_ascii_case("count") {
+        return None;
+    }
+    if !expressions_match(array, total_array) {
+        return None;
+    }
+    Some((array, type_expr))
+}
+
+/// `ARR findIf {!(_x isEqualType T)}` compared against a `-1` or `0` sentinel.
+fn check_findif<'a>(
+    cmd: &BinaryCommand,
+    left: &'a Expression,
+    right: &'a Expression,
+) -> Option<(&'a Expression, &'a Expression, bool)> {
+    // the comparison is normalised so the findIf is always on the left
+    let (find, sentinel, cmd) = match as_findif(left) {
+        Some(find) => (find, right, flip(cmd, false)),
+        None => (as_findif(right)?, left, flip(cmd, true)),
+    };
+    let negated = findif_polarity(&cmd, as_number(sentinel)?)?;
+    Some((find.0, find.1, negated))
+}
+
+/// Matches `ARR findIf {!(_x isEqualType T)}`, returning the array and the type.
+fn as_findif(expr: &Expression) -> Option<(&Expression, &Expression)> {
+    let Expression::BinaryCommand(BinaryCommand::Named(name), array, code, _) = expr else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("findIf") {
+        return None;
+    }
+    let type_expr = as_x_is_equal_type(unwrap_code_block(code), true)?;
+    Some((array, type_expr))
+}
+
+/// Swaps a comparison so its operands can be read in the other order.
+fn flip(cmd: &BinaryCommand, swap: bool) -> BinaryCommand {
+    if !swap {
+        return cmd.clone();
+    }
+    match cmd {
+        BinaryCommand::Less => BinaryCommand::Greater,
+        BinaryCommand::Greater => BinaryCommand::Less,
+        BinaryCommand::LessEq => BinaryCommand::GreaterEq,
+        BinaryCommand::GreaterEq => BinaryCommand::LessEq,
+        other => other.clone(),
+    }
+}
+
+/// True when the comparison is an inequality, false when equality, None when neither.
+fn equality_polarity(cmd: &BinaryCommand) -> Option<bool> {
+    if matches!(cmd, BinaryCommand::Eq)
+        || matches!(cmd, BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isEqualTo"))
+    {
+        return Some(false);
+    }
+    if matches!(cmd, BinaryCommand::NotEq)
+        || matches!(cmd, BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isNotEqualTo"))
+    {
+        return Some(true);
+    }
+    None
+}
+
+/// `findIf` yields -1 or an index in [0, inf), so each accepted shape below is exactly a test
+/// for -1, or its negation. Returns true when the expression means "not all matched".
+fn findif_polarity(cmd: &BinaryCommand, sentinel: f32) -> Option<bool> {
+    let is = |value: f32| (sentinel - value).abs() < f32::EPSILON;
+    if matches!(cmd, BinaryCommand::Eq if is(-1.0))
+        || matches!(cmd, BinaryCommand::LessEq if is(-1.0))
+        || matches!(cmd, BinaryCommand::Less if is(0.0))
+        || matches!(cmd, BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isEqualTo") && is(-1.0))
+    {
+        return Some(false);
+    }
+    if matches!(cmd, BinaryCommand::NotEq if is(-1.0))
+        || matches!(cmd, BinaryCommand::Greater if is(-1.0))
+        || matches!(cmd, BinaryCommand::GreaterEq if is(0.0))
+        || matches!(cmd, BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isNotEqualTo") && is(-1.0))
+    {
+        return Some(true);
+    }
+    None
+}
+
+/// Reads a numeric literal, seeing through a unary minus, as `-1` parses as `Minus` over `1`.
+fn as_number(expr: &Expression) -> Option<f32> {
+    match expr {
+        Expression::Number(value, _) => Some(value.0),
+        Expression::UnaryCommand(UnaryCommand::Minus, inner, _) => as_number(inner).map(|v| -v),
+        _ => None,
+    }
+}
+
+/// Matches `_x isEqualType T`, optionally wrapped in a `!`.
+fn as_x_is_equal_type(expr: &Expression, negated: bool) -> Option<&Expression> {
+    let expr = if negated {
+        let Expression::UnaryCommand(UnaryCommand::Not, inner, _) = expr else {
+            return None;
+        };
+        &**inner
+    } else {
+        expr
+    };
+    let Expression::BinaryCommand(BinaryCommand::Named(name), lhs, rhs, _) = expr else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("isEqualType") {
+        return None;
+    }
+    // the magic variable is spelled exactly `_x`, anything else is a different variable
+    let Expression::Variable(var, _) = &**lhs else {
+        return None;
+    };
+    if var != "_x" {
+        return None;
+    }
+    Some(rhs)
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS48IsEqualTypeAll {
+    span: Range<usize>,
+    array: String,
+    type_expr: String,
+    negated: bool,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS48IsEqualTypeAll {
+    fn ident(&self) -> &'static str {
+        "L-S48"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#is_equal_type_all")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        String::from("code can be replaced with `isEqualTypeAll`")
+    }
+
+    fn label_message(&self) -> String {
+        String::from("use `isEqualTypeAll`")
+    }
+
+    fn note(&self) -> Option<String> {
+        // isEqualTypeAll is false for an empty array, so the two disagree there either way round
+        Some(String::from(if self.negated {
+            "`isEqualTypeAll` returns false for an empty array, so this suggestion returns true where the original returns false"
+        } else {
+            "`isEqualTypeAll` returns false for an empty array, where this check returns true"
+        }))
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(if self.negated {
+            format!("!({} isEqualTypeAll {})", self.array, self.type_expr)
+        } else {
+            format!("{} isEqualTypeAll {}", self.array, self.type_expr)
+        })
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS48IsEqualTypeAll {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        array: String,
+        type_expr: String,
+        negated: bool,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            array,
+            type_expr,
+            negated,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}
+
+/// Check if two expressions match, considering variables and numbers
+fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
+    match (expr1, expr2) {
+        (Expression::Variable(v1, _), Expression::Variable(v2, _)) => v1 == v2,
+        (Expression::Number(n1, _), Expression::Number(n2, _)) => {
+            (n1.0 - n2.0).abs() < f32::EPSILON
+        }
+        _ => false,
+    }
+}
+
+/// Unwrap a code block to get the inner expression
+fn unwrap_code_block(expr: &Expression) -> &Expression {
+    if let Expression::Code(statements) = expr
+        && let Some(crate::Statement::Expression(inner, _)) = statements.content().first()
+    {
+        return inner;
+    }
+    expr
+}

--- a/libs/sqf/src/analyze/lints/s49_count_type.rs
+++ b/libs/sqf/src/analyze/lints/s49_count_type.rs
@@ -1,0 +1,181 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, analyze::LintData};
+
+crate::analyze::lint!(LintS49CountType);
+
+impl Lint<LintData> for LintS49CountType {
+    fn ident(&self) -> &'static str {
+        "count_type"
+    }
+
+    fn sort(&self) -> u32 {
+        490
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for counting objects of a type, which can be replaced with `countType`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r#"### Example
+
+**Incorrect**
+```sqf
+private _tanks = {_x isKindOf "Tank"} count _units;
+```
+**Correct**
+```sqf
+private _tanks = "Tank" countType _units;
+```
+
+### Explanation
+
+`countType` counts how many objects in an array are of a given type, including parent classes,
+in a single command."#
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        // {_x isKindOf TYPE} count ARR
+        let Expression::BinaryCommand(BinaryCommand::Named(cmd), code, array, _) = target else {
+            return Vec::new();
+        };
+        if !cmd.eq_ignore_ascii_case("count") {
+            return Vec::new();
+        }
+        let Some(type_expr) = as_kind_of(unwrap_code_block(code)) else {
+            return Vec::new();
+        };
+
+        vec![Arc::new(CodeS49CountType::new(
+            target.full_span(),
+            type_expr.source(true),
+            array.source(true),
+            processed,
+            config.severity(),
+        ))]
+    }
+}
+
+/// Matches `_x isKindOf TYPE`, returning TYPE.
+fn as_kind_of(expr: &Expression) -> Option<&Expression> {
+    let Expression::BinaryCommand(BinaryCommand::Named(name), lhs, rhs, _) = expr else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("isKindOf") {
+        return None;
+    }
+    // the magic variable is spelled exactly `_x`, anything else is a different variable
+    let Expression::Variable(var, _) = &**lhs else {
+        return None;
+    };
+    if var != "_x" {
+        return None;
+    }
+    Some(rhs)
+}
+
+/// Unwrap a code block to get the inner expression
+fn unwrap_code_block(expr: &Expression) -> &Expression {
+    if let Expression::Code(statements) = expr
+        && let Some(crate::Statement::Expression(inner, _)) = statements.content().first()
+    {
+        return inner;
+    }
+    expr
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS49CountType {
+    span: Range<usize>,
+    type_name: String,
+    array: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS49CountType {
+    fn ident(&self) -> &'static str {
+        "L-S49"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#count_type")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        String::from("code can be replaced with `countType`")
+    }
+
+    fn label_message(&self) -> String {
+        String::from("use `countType`")
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("{} countType {}", self.type_name, self.array))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS49CountType {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        type_name: String,
+        array: String,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            type_name,
+            array,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s50_count_side.rs
+++ b/libs/sqf/src/analyze/lints/s50_count_side.rs
@@ -1,0 +1,194 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, UnaryCommand, analyze::LintData};
+
+crate::analyze::lint!(LintS50CountSide);
+
+impl Lint<LintData> for LintS50CountSide {
+    fn ident(&self) -> &'static str {
+        "count_side"
+    }
+
+    fn sort(&self) -> u32 {
+        500
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for counting units of a side, which can be replaced with `countSide`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+private _west = {side _x == west} count _units;
+```
+**Correct**
+```sqf
+private _west = west countSide _units;
+```
+
+### Explanation
+
+`countSide` counts how many units in an array belong to a given side in a single command.
+
+Only `side _x` is matched. A unit's own side can differ from its group's, so `side group _x`
+and `side leader _x` are left alone."
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+
+        // {_x isKindOf TYPE} count ARR
+        let Expression::BinaryCommand(BinaryCommand::Named(cmd), code, array, _) = target else {
+            return Vec::new();
+        };
+        if !cmd.eq_ignore_ascii_case("count") {
+            return Vec::new();
+        }
+        let Some(type_expr) = as_side_comparison(unwrap_code_block(code)) else {
+            return Vec::new();
+        };
+
+        vec![Arc::new(CodeS50CountSide::new(
+            target.full_span(),
+            type_expr.source(true),
+            array.source(true),
+            processed,
+            config.severity(),
+        ))]
+    }
+}
+
+/// Matches `side _x == SIDE` in either operand order, returning SIDE.
+fn as_side_comparison(expr: &Expression) -> Option<&Expression> {
+    let Expression::BinaryCommand(cmd, lhs, rhs, _) = expr else {
+        return None;
+    };
+    let is_eq = matches!(cmd, BinaryCommand::Eq)
+        || matches!(cmd, BinaryCommand::Named(name) if name.eq_ignore_ascii_case("isEqualTo"));
+    if !is_eq {
+        return None;
+    }
+    if is_side_of_x(lhs) {
+        return Some(rhs);
+    }
+    if is_side_of_x(rhs) {
+        return Some(lhs);
+    }
+    None
+}
+
+/// Matches `side _x`, and nothing else. `side group _x` is a different value entirely.
+fn is_side_of_x(expr: &Expression) -> bool {
+    let Expression::UnaryCommand(UnaryCommand::Named(name), inner, _) = expr else {
+        return false;
+    };
+    // the magic variable is spelled exactly `_x`, anything else is a different variable
+    name.eq_ignore_ascii_case("side")
+        && matches!(&**inner, Expression::Variable(var, _) if var == "_x")
+}
+
+/// Unwrap a code block to get the inner expression
+fn unwrap_code_block(expr: &Expression) -> &Expression {
+    if let Expression::Code(statements) = expr
+        && let Some(crate::Statement::Expression(inner, _)) = statements.content().first()
+    {
+        return inner;
+    }
+    expr
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS50CountSide {
+    span: Range<usize>,
+    side: String,
+    array: String,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS50CountSide {
+    fn ident(&self) -> &'static str {
+        "L-S50"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#count_side")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        String::from("code can be replaced with `countSide`")
+    }
+
+    fn label_message(&self) -> String {
+        String::from("use `countSide`")
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("{} countSide {}", self.side, self.array))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS50CountSide {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        side: String,
+        array: String,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            side,
+            array,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}

--- a/libs/sqf/src/analyze/lints/s50_count_side.rs
+++ b/libs/sqf/src/analyze/lints/s50_count_side.rs
@@ -69,7 +69,7 @@ impl LintRunner<LintData> for Runner {
             return Vec::new();
         };
 
-        // {_x isKindOf TYPE} count ARR
+        // {side _x == SIDE} count ARR
         let Expression::BinaryCommand(BinaryCommand::Named(cmd), code, array, _) = target else {
             return Vec::new();
         };

--- a/libs/sqf/src/analyze/lints/s51_push_back_unique.rs
+++ b/libs/sqf/src/analyze/lints/s51_push_back_unique.rs
@@ -1,0 +1,255 @@
+use std::{ops::Range, sync::Arc};
+
+use hemtt_common::config::LintConfig;
+use hemtt_workspace::{
+    lint::{AnyLintRunner, Lint, LintRunner},
+    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+};
+
+use crate::{BinaryCommand, Expression, Statement, UnaryCommand, analyze::LintData};
+
+crate::analyze::lint!(LintS51PushBackUnique);
+
+impl Lint<LintData> for LintS51PushBackUnique {
+    fn ident(&self) -> &'static str {
+        "push_back_unique"
+    }
+
+    fn sort(&self) -> u32 {
+        510
+    }
+
+    fn description(&self) -> &'static str {
+        "Checks for guarding `pushBack` with `in`, which can be replaced with `pushBackUnique`"
+    }
+
+    fn documentation(&self) -> &'static str {
+        r"### Example
+
+**Incorrect**
+```sqf
+if !(_value in _list) then {_list pushBack _value};
+```
+**Correct**
+```sqf
+_list pushBackUnique _value;
+```
+
+### Explanation
+
+`pushBackUnique` only adds the element if it is not already in the array, so the surrounding
+`in` check is doing work the command already does.
+
+The same shape already using `pushBackUnique` is reported as a redundant check. `in` and
+`pushBackUnique` are both case sensitive on strings, so the replacement is exact."
+    }
+
+    fn default_config(&self) -> LintConfig {
+        LintConfig::help()
+    }
+
+    fn runners(&self) -> Vec<Box<dyn AnyLintRunner<LintData>>> {
+        vec![Box::new(Runner)]
+    }
+}
+
+struct Runner;
+impl LintRunner<LintData> for Runner {
+    type Target = Expression;
+
+    fn run(
+        &self,
+        _project: Option<&hemtt_common::config::ProjectConfig>,
+        config: &LintConfig,
+        processed: Option<&hemtt_workspace::reporting::Processed>,
+        _runtime: &hemtt_common::config::RuntimeArguments,
+        target: &Self::Target,
+        _data: &LintData,
+    ) -> Codes {
+        let Some(processed) = processed else {
+            return Vec::new();
+        };
+        check(target, processed, config)
+    }
+}
+
+// Pattern 1: if !(x in arr) then {arr pushBack x}        -> arr pushBackUnique x
+// Pattern 2: if !(x in arr) then {arr pushBackUnique x}  -> the check is already done by the command
+//
+// `in` and `pushBackUnique` are both case sensitive on strings, so the two are equivalent.
+
+fn check(target: &Expression, processed: &Processed, config: &LintConfig) -> Vec<Arc<dyn Code>> {
+    let mut codes = Vec::new();
+
+    // if ... then {...}, with no else branch
+    let Expression::BinaryCommand(BinaryCommand::Named(then_cmd), if_expr, code, _) = target else {
+        return codes;
+    };
+    if !then_cmd.eq_ignore_ascii_case("then") {
+        return codes;
+    }
+    let Expression::UnaryCommand(UnaryCommand::Named(if_cmd), condition, _) = &**if_expr else {
+        return codes;
+    };
+    if !if_cmd.eq_ignore_ascii_case("if") {
+        return codes;
+    }
+
+    let Some((needle, haystack)) = as_negated_in(condition) else {
+        return codes;
+    };
+    let Some((array, value, already_unique)) = as_push(code) else {
+        return codes;
+    };
+
+    // the array searched has to be the array pushed to, and the value likewise
+    if !expressions_match(haystack, array)
+        || !expressions_match(needle, value)
+    {
+        return codes;
+    }
+
+    codes.push(Arc::new(CodeS51PushBackUnique::new(
+        target.full_span(),
+        array.source(true),
+        value.source(true),
+        already_unique,
+        processed,
+        config.severity(),
+    )) as Arc<dyn Code>);
+    codes
+}
+
+/// Matches `!(x in arr)`, returning the needle and the haystack.
+fn as_negated_in(expr: &Expression) -> Option<(&Expression, &Expression)> {
+    let Expression::UnaryCommand(UnaryCommand::Not, inner, _) = expr else {
+        return None;
+    };
+    let Expression::BinaryCommand(BinaryCommand::Named(name), needle, haystack, _) = &**inner
+    else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("in") {
+        return None;
+    }
+    Some((needle, haystack))
+}
+
+/// Matches a lone `arr pushBack x` or `arr pushBackUnique x` in the then branch.
+/// The bool is true when it is already `pushBackUnique`, so the guard is simply redundant.
+fn as_push(expr: &Expression) -> Option<(&Expression, &Expression, bool)> {
+    let Expression::Code(statements) = expr else {
+        return None;
+    };
+    // anything else in the branch means the guard is doing more than the command would
+    if statements.content().len() != 1 {
+        return None;
+    }
+    let Statement::Expression(Expression::BinaryCommand(BinaryCommand::Named(name), array, value, _), _) =
+        &statements.content()[0]
+    else {
+        return None;
+    };
+    if name.eq_ignore_ascii_case("pushBack") {
+        return Some((array, value, false));
+    }
+    if name.eq_ignore_ascii_case("pushBackUnique") {
+        return Some((array, value, true));
+    }
+    None
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub struct CodeS51PushBackUnique {
+    span: Range<usize>,
+    array: String,
+    value: String,
+    already_unique: bool,
+    severity: Severity,
+    diagnostic: Option<Diagnostic>,
+}
+
+impl Code for CodeS51PushBackUnique {
+    fn ident(&self) -> &'static str {
+        "L-S51"
+    }
+
+    fn link(&self) -> Option<&str> {
+        Some("/lints/sqf.html#push_back_unique")
+    }
+
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    fn message(&self) -> String {
+        if self.already_unique {
+            String::from("`pushBackUnique` already checks this")
+        } else {
+            String::from("code can be replaced with `pushBackUnique`")
+        }
+    }
+
+    fn label_message(&self) -> String {
+        if self.already_unique {
+            String::from("redundant check")
+        } else {
+            String::from("use `pushBackUnique`")
+        }
+    }
+
+    fn note(&self) -> Option<String> {
+        if self.already_unique {
+            return Some(String::from(
+                "`pushBackUnique` only adds the element if it is not already in the array",
+            ));
+        }
+        None
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some(format!("{} pushBackUnique {}", self.array, self.value))
+    }
+
+    fn diagnostic(&self) -> Option<Diagnostic> {
+        self.diagnostic.clone()
+    }
+}
+
+impl CodeS51PushBackUnique {
+    #[must_use]
+    pub fn new(
+        span: Range<usize>,
+        array: String,
+        value: String,
+        already_unique: bool,
+        processed: &Processed,
+        severity: Severity,
+    ) -> Self {
+        Self {
+            span,
+            array,
+            value,
+            already_unique,
+            severity,
+            diagnostic: None,
+        }
+        .generate_processed(processed)
+    }
+
+    fn generate_processed(mut self, processed: &Processed) -> Self {
+        self.diagnostic = Diagnostic::from_code_processed(&self, self.span.clone(), processed);
+        self
+    }
+}
+
+/// Check if two expressions match, considering variables and numbers
+fn expressions_match(expr1: &Expression, expr2: &Expression) -> bool {
+    match (expr1, expr2) {
+        (Expression::Variable(v1, _), Expression::Variable(v2, _)) => v1 == v2,
+        (Expression::Number(n1, _), Expression::Number(n2, _)) => {
+            (n1.0 - n2.0).abs() < f32::EPSILON
+        }
+        _ => false,
+    }
+}

--- a/libs/sqf/tests/lints.rs
+++ b/libs/sqf/tests/lints.rs
@@ -81,6 +81,12 @@ lint!(s42_for_range, true);
 lint!(s43_array_setcount, true);
 lint!(s44_string_concat_format, true);
 lint!(s45_array_append, true);
+lint!(s46_is_equal_type, true);
+lint!(s47_is_equal_type_any, true);
+lint!(s48_is_equal_type_all, true);
+lint!(s49_count_type, true);
+lint!(s50_count_side, true);
+lint!(s51_push_back_unique, true);
 
 #[test]
 fn test_s29_function_undefined() {

--- a/libs/sqf/tests/lints/s46_is_equal_type.sqf
+++ b/libs/sqf/tests/lints/s46_is_equal_type.sqf
@@ -1,0 +1,21 @@
+private _a = "hello";
+private _b = 5;
+
+// both sides are typeName, reported
+if (typeName _a == typeName _b) then { };
+if (typeName _a isEqualTo typeName _b) then { };
+
+// negated forms, reported as !(... isEqualType ...)
+if (typeName _a != typeName _b) then { };
+if (typeName _a isNotEqualTo typeName _b) then { };
+
+// only one side is typeName, left to the static_typename lint
+if (typeName _a == "STRING") then { };
+if ("STRING" == typeName _a) then { };
+
+// both sides are typeName, so this is reported here as well as by static_typename
+if (typeName _a == typeName "") then { };
+
+// not a comparison of types, ignore
+if (_a isEqualType _b) then { };
+if (count _a == count _b) then { };

--- a/libs/sqf/tests/lints/s47_is_equal_type_any.sqf
+++ b/libs/sqf/tests/lints/s47_is_equal_type_any.sqf
@@ -1,0 +1,18 @@
+private _x = 5;
+
+// chains of isEqualType on the same value, reported
+if (_x isEqualType 0 || _x isEqualType "") then { };
+if (_x isEqualType 0 || _x isEqualType "" || _x isEqualType objNull) then { };
+
+// short circuited form, still the same pattern
+if (_x isEqualType 0 || {_x isEqualType ""}) then { };
+
+// different values compared, ignore
+if (_x isEqualType 0 || _y isEqualType "") then { };
+
+// only one comparison, ignore
+if (_x isEqualType 0) then { };
+
+// not isEqualType, ignore
+if (_x isEqualTo 0 || _x isEqualTo "") then { };
+if (_x isEqualType 0 && _x isEqualType "") then { };

--- a/libs/sqf/tests/lints/s48_is_equal_type_all.sqf
+++ b/libs/sqf/tests/lints/s48_is_equal_type_all.sqf
@@ -1,0 +1,37 @@
+private _arr = [1, 2, 3];
+
+// count pattern, reported
+if ({_x isEqualType 0} count _arr == count _arr) then { };
+if (count _arr == {_x isEqualType 0} count _arr) then { };
+if ({_x isEqualType ""} count _arr isEqualTo count _arr) then { };
+
+// findIf pattern, reported
+if (_arr findIf {!(_x isEqualType 0)} == -1) then { };
+if (_arr findIf {!(_x isEqualType 0)} < 0) then { };
+if (_arr findIf {!(_x isEqualType 0)} <= -1) then { };
+if (-1 == _arr findIf {!(_x isEqualType 0)}) then { };
+if (0 > _arr findIf {!(_x isEqualType 0)}) then { };
+
+// negated forms, reported as !(... isEqualTypeAll ...)
+if ({_x isEqualType 0} count _arr != count _arr) then { };
+if (_arr findIf {!(_x isEqualType 0)} != -1) then { };
+if (_arr findIf {!(_x isEqualType 0)} > -1) then { };
+if (_arr findIf {!(_x isEqualType 0)} >= 0) then { };
+if (0 <= _arr findIf {!(_x isEqualType 0)}) then { };
+
+// counting a different array, ignore
+if ({_x isEqualType 0} count _arr == count _other) then { };
+
+// not the magic _x, ignore
+if ({_y isEqualType 0} count _arr == count _arr) then { };
+
+// findIf without the negation is a different question, ignore
+if (_arr findIf {_x isEqualType 0} == -1) then { };
+
+// sentinel that does not correspond to a -1 test, ignore
+if (_arr findIf {!(_x isEqualType 0)} == 2) then { };
+if (_arr findIf {!(_x isEqualType 0)} > 0) then { };
+
+// unrelated comparisons, ignore
+if (count _arr == 0) then { };
+if ({_x > 2} count _arr == count _arr) then { };

--- a/libs/sqf/tests/lints/s49_count_type.sqf
+++ b/libs/sqf/tests/lints/s49_count_type.sqf
@@ -1,0 +1,12 @@
+private _units = units player;
+
+// reported
+private _tanks = {_x isKindOf "Tank"} count _units;
+private _medics = {_x isKindOf "B_medic_F"} count allUnits;
+
+// not the magic _x, ignore
+private _other = {_y isKindOf "Tank"} count _units;
+
+// unrelated counts, ignore
+private _alive = {alive _x} count _units;
+private _plain = count _units;

--- a/libs/sqf/tests/lints/s50_count_side.sqf
+++ b/libs/sqf/tests/lints/s50_count_side.sqf
@@ -1,0 +1,16 @@
+private _units = units player;
+
+// reported, either operand order
+private _west = {side _x == west} count _units;
+private _east = {east == side _x} count _units;
+private _civ = {side _x isEqualTo civilian} count _units;
+
+// side of the group is not the side of the unit, ignore
+private _grouped = {side group _x == west} count _units;
+private _leader = {side leader _x == west} count _units;
+
+// not the magic _x, ignore
+private _other = {side _y == west} count _units;
+
+// unrelated counts, ignore
+private _alive = {alive _x} count _units;

--- a/libs/sqf/tests/lints/s51_push_back_unique.sqf
+++ b/libs/sqf/tests/lints/s51_push_back_unique.sqf
@@ -1,0 +1,26 @@
+private _addons = [];
+private _paramAddons = ["a", "b"];
+
+// the ACE3 pattern this came from, both reported
+{
+    if !(_x in _addons) then {_addons pushBack _x};
+    if !(_x in _addons) then {_addons pushBackUnique _x};
+} forEach _paramAddons;
+
+// plain variables, reported
+if !(_value in _list) then {_list pushBack _value};
+
+// searched array is not the pushed array, ignore
+if !(_value in _list) then {_other pushBack _value};
+
+// pushed value is not the searched value, ignore
+if !(_value in _list) then {_list pushBack _somethingElse};
+
+// branch does more than push, the guard is not redundant, ignore
+if !(_value in _list) then {_list pushBack _value; _count = _count + 1};
+
+// not negated, ignore
+if (_value in _list) then {_list pushBack _value};
+
+// has an else branch, ignore
+if !(_value in _list) then {_list pushBack _value} else {_list pushBack 0};

--- a/libs/sqf/tests/snapshots/lints__simple_s03_static_typename.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s03_static_typename.snap
@@ -36,3 +36,21 @@ expression: "lint(stringify! (s03_static_typename), true).0"
    [0m[36m│[0m      [0m[33m^^^^^^^^^^^^^[0m [0m[33m`typeName` on a constant[0m
    [0m[36m│[0m
    [0m[36m=[0m [32mtry[0m: "NaN"
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+  [0m[36m┌─[0m s03_static_typename.sqf:3:5
+  [0m[36m│[0m
+[0m[36m3[0m [0m[36m│[0m if ([0m[36mtypeName 0 == typeName _thing[0m) then {
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: 0 isEqualType _thing
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+  [0m[36m┌─[0m s03_static_typename.sqf:9:24
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m private _aliveIsBool = [0m[36mtypeName true == typeName alive player[0m;
+  [0m[36m│[0m                        [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: true isEqualType alive player

--- a/libs/sqf/tests/snapshots/lints__simple_s46_is_equal_type.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s46_is_equal_type.snap
@@ -1,0 +1,56 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s46_is_equal_type), true).0"
+---
+[0m[1m[38;5;11mwarning[L-S03][0m[1m: using `typeName` on a constant is slower than using the type directly[0m
+   [0m[36m┌─[0m s46_is_equal_type.sqf:17:20
+   [0m[36m│[0m
+[0m[36m17[0m [0m[36m│[0m if (typeName _a == [0m[33mtypeName ""[0m) then { };
+   [0m[36m│[0m                    [0m[33m^^^^^^^^^^^[0m [0m[33m`typeName` on a constant[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: "STRING"
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+  [0m[36m┌─[0m s46_is_equal_type.sqf:5:5
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m if ([0m[36mtypeName _a == typeName _b[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _a isEqualType _b
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+  [0m[36m┌─[0m s46_is_equal_type.sqf:6:5
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m if ([0m[36mtypeName _a isEqualTo typeName _b[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _a isEqualType _b
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+  [0m[36m┌─[0m s46_is_equal_type.sqf:9:5
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m if ([0m[36mtypeName _a != typeName _b[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: !(_a isEqualType _b)
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+   [0m[36m┌─[0m s46_is_equal_type.sqf:10:5
+   [0m[36m│[0m
+[0m[36m10[0m [0m[36m│[0m if ([0m[36mtypeName _a isNotEqualTo typeName _b[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: !(_a isEqualType _b)
+
+
+[0m[1m[38;5;14mhelp[L-S46][0m[1m: code can be replaced with `isEqualType`[0m
+   [0m[36m┌─[0m s46_is_equal_type.sqf:17:5
+   [0m[36m│[0m
+[0m[36m17[0m [0m[36m│[0m if ([0m[36mtypeName _a == typeName ""[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualType`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: _a isEqualType ""

--- a/libs/sqf/tests/snapshots/lints__simple_s47_is_equal_type_any.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s47_is_equal_type_any.snap
@@ -1,0 +1,38 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s47_is_equal_type_any), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S26][0m[1m: Inefficent short circuit evaulation[0m
+  [0m[36m┌─[0m s47_is_equal_type_any.sqf:8:26
+  [0m[36m│[0m
+[0m[36m8[0m [0m[36m│[0m if (_x isEqualType 0 || {[0m[36m_x isEqualType ""[0m}) then { };
+  [0m[36m│[0m                          [0m[36m^^^^^^^^^^^^^^^^^[0m [0m[36munnecessary { }[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: remove the { } and use the comparison directly, it is cheaper than the short circuit
+
+
+[0m[1m[38;5;14mhelp[L-S47][0m[1m: code can be replaced with `isEqualTypeAny`[0m
+  [0m[36m┌─[0m s47_is_equal_type_any.sqf:4:5
+  [0m[36m│[0m
+[0m[36m4[0m [0m[36m│[0m if ([0m[36m_x isEqualType 0 || _x isEqualType ""[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAny`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _x isEqualTypeAny [0, ""]
+
+
+[0m[1m[38;5;14mhelp[L-S47][0m[1m: code can be replaced with `isEqualTypeAny`[0m
+  [0m[36m┌─[0m s47_is_equal_type_any.sqf:5:5
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m if ([0m[36m_x isEqualType 0 || _x isEqualType ""[0m || _x isEqualType objNull) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAny`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _x isEqualTypeAny [0, ""]
+
+
+[0m[1m[38;5;14mhelp[L-S47][0m[1m: code can be replaced with `isEqualTypeAny`[0m
+  [0m[36m┌─[0m s47_is_equal_type_any.sqf:8:5
+  [0m[36m│[0m
+[0m[36m8[0m [0m[36m│[0m if ([0m[36m_x isEqualType 0 || {_x isEqualType ""[0m}) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAny`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _x isEqualTypeAny [0, ""]

--- a/libs/sqf/tests/snapshots/lints__simple_s47_is_equal_type_any.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s47_is_equal_type_any.snap
@@ -23,10 +23,10 @@ expression: "lint(stringify! (s47_is_equal_type_any), true).0"
 [0m[1m[38;5;14mhelp[L-S47][0m[1m: code can be replaced with `isEqualTypeAny`[0m
   [0m[36m┌─[0m s47_is_equal_type_any.sqf:5:5
   [0m[36m│[0m
-[0m[36m5[0m [0m[36m│[0m if ([0m[36m_x isEqualType 0 || _x isEqualType ""[0m || _x isEqualType objNull) then { };
-  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAny`[0m
+[0m[36m5[0m [0m[36m│[0m if ([0m[36m_x isEqualType 0 || _x isEqualType "" || _x isEqualType objNull[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAny`[0m
   [0m[36m│[0m
-  [0m[36m=[0m [32mtry[0m: _x isEqualTypeAny [0, ""]
+  [0m[36m=[0m [32mtry[0m: _x isEqualTypeAny [0, "", objNull]
 
 
 [0m[1m[38;5;14mhelp[L-S47][0m[1m: code can be replaced with `isEqualTypeAny`[0m

--- a/libs/sqf/tests/snapshots/lints__simple_s48_is_equal_type_all.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s48_is_equal_type_all.snap
@@ -1,0 +1,132 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s48_is_equal_type_all), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+  [0m[36m┌─[0m s48_is_equal_type_all.sqf:4:6
+  [0m[36m│[0m
+[0m[36m4[0m [0m[36m│[0m if ({[0m[36m_x isEqualType 0} count _arr == count _arr[0m) then { };
+  [0m[36m│[0m      [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+  [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+  [0m[36m┌─[0m s48_is_equal_type_all.sqf:5:5
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m if ([0m[36mcount _arr == {_x isEqualType 0} count _arr[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+  [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+  [0m[36m┌─[0m s48_is_equal_type_all.sqf:6:6
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m if ({[0m[36m_x isEqualType ""} count _arr isEqualTo count _arr[0m) then { };
+  [0m[36m│[0m      [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+  [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll ""
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+  [0m[36m┌─[0m s48_is_equal_type_all.sqf:9:5
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m if ([0m[36m_arr findIf {!(_x isEqualType 0)} == -1[0m) then { };
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+  [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:10:5
+   [0m[36m│[0m
+[0m[36m10[0m [0m[36m│[0m if ([0m[36m_arr findIf {!(_x isEqualType 0)} < 0[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+   [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:11:5
+   [0m[36m│[0m
+[0m[36m11[0m [0m[36m│[0m if ([0m[36m_arr findIf {!(_x isEqualType 0)} <= -1[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+   [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:12:5
+   [0m[36m│[0m
+[0m[36m12[0m [0m[36m│[0m if ([0m[36m-1 == _arr findIf {!(_x isEqualType 0)[0m}) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+   [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:13:5
+   [0m[36m│[0m
+[0m[36m13[0m [0m[36m│[0m if ([0m[36m0 > _arr findIf {!(_x isEqualType 0)[0m}) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, where this check returns true
+   [0m[36m=[0m [32mtry[0m: _arr isEqualTypeAll 0
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:16:6
+   [0m[36m│[0m
+[0m[36m16[0m [0m[36m│[0m if ({[0m[36m_x isEqualType 0} count _arr != count _arr[0m) then { };
+   [0m[36m│[0m      [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, so this suggestion returns true where the original returns false
+   [0m[36m=[0m [32mtry[0m: !(_arr isEqualTypeAll 0)
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:17:5
+   [0m[36m│[0m
+[0m[36m17[0m [0m[36m│[0m if ([0m[36m_arr findIf {!(_x isEqualType 0)} != -1[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, so this suggestion returns true where the original returns false
+   [0m[36m=[0m [32mtry[0m: !(_arr isEqualTypeAll 0)
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:18:5
+   [0m[36m│[0m
+[0m[36m18[0m [0m[36m│[0m if ([0m[36m_arr findIf {!(_x isEqualType 0)} > -1[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, so this suggestion returns true where the original returns false
+   [0m[36m=[0m [32mtry[0m: !(_arr isEqualTypeAll 0)
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:19:5
+   [0m[36m│[0m
+[0m[36m19[0m [0m[36m│[0m if ([0m[36m_arr findIf {!(_x isEqualType 0)} >= 0[0m) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, so this suggestion returns true where the original returns false
+   [0m[36m=[0m [32mtry[0m: !(_arr isEqualTypeAll 0)
+
+
+[0m[1m[38;5;14mhelp[L-S48][0m[1m: code can be replaced with `isEqualTypeAll`[0m
+   [0m[36m┌─[0m s48_is_equal_type_all.sqf:20:5
+   [0m[36m│[0m
+[0m[36m20[0m [0m[36m│[0m if ([0m[36m0 <= _arr findIf {!(_x isEqualType 0)[0m}) then { };
+   [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `isEqualTypeAll`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [36mnote[0m: `isEqualTypeAll` returns false for an empty array, so this suggestion returns true where the original returns false
+   [0m[36m=[0m [32mtry[0m: !(_arr isEqualTypeAll 0)

--- a/libs/sqf/tests/snapshots/lints__simple_s49_count_type.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s49_count_type.snap
@@ -1,0 +1,20 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s49_count_type), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S49][0m[1m: code can be replaced with `countType`[0m
+  [0m[36m┌─[0m s49_count_type.sqf:4:19
+  [0m[36m│[0m
+[0m[36m4[0m [0m[36m│[0m private _tanks = {[0m[36m_x isKindOf "Tank"} count _units[0m;
+  [0m[36m│[0m                   [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: "Tank" countType _units
+
+
+[0m[1m[38;5;14mhelp[L-S49][0m[1m: code can be replaced with `countType`[0m
+  [0m[36m┌─[0m s49_count_type.sqf:5:20
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m private _medics = {[0m[36m_x isKindOf "B_medic_F"} count allUnits[0m;
+  [0m[36m│[0m                    [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countType`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: "B_medic_F" countType allUnits

--- a/libs/sqf/tests/snapshots/lints__simple_s50_count_side.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s50_count_side.snap
@@ -1,0 +1,29 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s50_count_side), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S50][0m[1m: code can be replaced with `countSide`[0m
+  [0m[36m┌─[0m s50_count_side.sqf:4:18
+  [0m[36m│[0m
+[0m[36m4[0m [0m[36m│[0m private _west = {[0m[36mside _x == west} count _units[0m;
+  [0m[36m│[0m                  [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countSide`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: west countSide _units
+
+
+[0m[1m[38;5;14mhelp[L-S50][0m[1m: code can be replaced with `countSide`[0m
+  [0m[36m┌─[0m s50_count_side.sqf:5:18
+  [0m[36m│[0m
+[0m[36m5[0m [0m[36m│[0m private _east = {[0m[36meast == side _x} count _units[0m;
+  [0m[36m│[0m                  [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countSide`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: east countSide _units
+
+
+[0m[1m[38;5;14mhelp[L-S50][0m[1m: code can be replaced with `countSide`[0m
+  [0m[36m┌─[0m s50_count_side.sqf:6:17
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m private _civ = {[0m[36mside _x isEqualTo civilian} count _units[0m;
+  [0m[36m│[0m                 [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `countSide`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: civilian countSide _units

--- a/libs/sqf/tests/snapshots/lints__simple_s51_push_back_unique.snap
+++ b/libs/sqf/tests/snapshots/lints__simple_s51_push_back_unique.snap
@@ -1,0 +1,46 @@
+---
+source: libs/sqf/tests/lints.rs
+expression: "lint(stringify! (s51_push_back_unique), true).0"
+---
+[0m[1m[38;5;14mhelp[L-S11][0m[1m: Unneeded not in if[0m
+   [0m[36m┌─[0m s51_push_back_unique.sqf:26:4
+   [0m[36m│[0m
+[0m[36m26[0m [0m[36m│[0m if [0m[36m![0m(_value in _list) then {_list pushBack _value} else {_list pushBack 0};
+   [0m[36m│[0m    [0m[36m^[0m [0m[36munnecessary `!` operation[0m
+
+
+[0m[1m[38;5;14mhelp[L-S41][0m[1m: Use `apply` instead of `forEach` when `_forEachIndex` is unused[0m
+  [0m[36m┌─[0m s51_push_back_unique.sqf:8:3
+  [0m[36m│[0m
+[0m[36m8[0m [0m[36m│[0m } [0m[36mforEach[0m _paramAddons;
+  [0m[36m│[0m   [0m[36m^^^^^^^[0m [0m[36mforEach loop can use apply[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [33mhelp[0m: replace with `array apply { ... }`
+
+
+[0m[1m[38;5;14mhelp[L-S51][0m[1m: `pushBackUnique` already checks this[0m
+  [0m[36m┌─[0m s51_push_back_unique.sqf:7:5
+  [0m[36m│[0m
+[0m[36m7[0m [0m[36m│[0m     [0m[36mif !(_x in _addons) then {_addons pushBackUnique _x[0m};
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36mredundant check[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [36mnote[0m: `pushBackUnique` only adds the element if it is not already in the array
+  [0m[36m=[0m [32mtry[0m: _addons pushBackUnique _x
+
+
+[0m[1m[38;5;14mhelp[L-S51][0m[1m: code can be replaced with `pushBackUnique`[0m
+  [0m[36m┌─[0m s51_push_back_unique.sqf:6:5
+  [0m[36m│[0m
+[0m[36m6[0m [0m[36m│[0m     [0m[36mif !(_x in _addons) then {_addons pushBack _x[0m};
+  [0m[36m│[0m     [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `pushBackUnique`[0m
+  [0m[36m│[0m
+  [0m[36m=[0m [32mtry[0m: _addons pushBackUnique _x
+
+
+[0m[1m[38;5;14mhelp[L-S51][0m[1m: code can be replaced with `pushBackUnique`[0m
+   [0m[36m┌─[0m s51_push_back_unique.sqf:11:1
+   [0m[36m│[0m
+[0m[36m11[0m [0m[36m│[0m [0m[36mif !(_value in _list) then {_list pushBack _value[0m};
+   [0m[36m│[0m [0m[36m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [0m[36muse `pushBackUnique`[0m
+   [0m[36m│[0m
+   [0m[36m=[0m [32mtry[0m: _list pushBackUnique _value


### PR DESCRIPTION
- S46 `is_equal_type`      `typeName a == typeName b` -> `a isEqualType b`
- S47 `is_equal_type_any`  chained `isEqualType` -> `isEqualTypeAny`
- S48 `is_equal_type_all`  `count`/`findIf` type checks -> `isEqualTypeAll`
- S49 `count_type`         `{_x isKindOf t} count arr` -> `t countType arr`
- S50 `count_side`         `{side _x == s} count arr` -> `s countSide arr`
- S51 `push_back_unique`   `if !(x in arr) then {arr pushBack x}` ->
                            `arr pushBackUnique x`