### PR TITLE
hls: stop panicking on files outside an addon, align lints with the CLI

### DIFF
--- a/bin/src/modules/sqf.rs
+++ b/bin/src/modules/sqf.rs
@@ -51,13 +51,12 @@ impl Module for SQFCompiler {
 
     fn pre_build(&self, ctx: &Context) -> Result<Report, Error> {
         let mut report = Report::new();
-        let sqf_ext = Some(String::from("sqf"));
         let mut entries = Vec::new();
         for addon in ctx.addons() {
             let addon = Arc::new(addon.clone());
             for entry in ctx.workspace_path().join(addon.folder())?.walk_dir()? {
                 if entry.is_file()? {
-                    if entry.extension() != sqf_ext || entry.filename().ends_with(".inc.sqf") {
+                    if !hemtt_sqf::is_compilation_unit(&entry) {
                         continue;
                     }
                     entries.push((addon.clone(), entry));
@@ -117,9 +116,7 @@ impl Module for SQFCompiler {
                         Ok(report)
                     }
                     Err(ParserError::ParsingError(e)) => {
-                        if processed.as_str().starts_with("force ")
-                            || processed.as_str().contains("\nforce ")
-                        {
+                        if hemtt_sqf::is_cba_settings(processed.as_str()) {
                             debug!("skipping apparent CBA settings file: {}", entry);
                         } else {
                             for error in e {

--- a/hls/src/sqf/lints.rs
+++ b/hls/src/sqf/lints.rs
@@ -39,6 +39,29 @@ impl Cache {
     }
 }
 
+/// The [`Addon`] a workspace path belongs to, or `None` if it belongs to none.
+fn addon_for(workspace: &EditorWorkspace, path: &WorkspacePath) -> Option<Arc<Addon>> {
+    let location = if path.as_str().starts_with("/addons/") {
+        hemtt_workspace::addons::Location::Addons
+    } else if path.as_str().starts_with("/optionals/") {
+        hemtt_workspace::addons::Location::Optionals
+    } else {
+        debug!("not linting `{path}`, not in `addons/` or `optionals/`");
+        return None;
+    };
+    let Some(name) = path.as_str().split('/').nth(2).filter(|n| !n.is_empty()) else {
+        debug!("not linting `{path}`, no addon name in path");
+        return None;
+    };
+    match Addon::new(workspace.root_disk(), name.to_string(), location) {
+        Ok(addon) => Some(Arc::new(addon)),
+        Err(e) => {
+            debug!("not linting `{path}`, failed to create addon: {e}");
+            None
+        }
+    }
+}
+
 fn check_addons(workspace: &EditorWorkspace, database: &Arc<Database>, client: Client) {
     debug!("sqf: checking addons");
     let mut futures = JoinSet::new();
@@ -47,20 +70,11 @@ fn check_addons(workspace: &EditorWorkspace, database: &Arc<Database>, client: C
             warn!("failed to join addon {:?}", addon);
             continue;
         };
-        let location = if source.as_str().starts_with("/addons/") {
-            hemtt_workspace::addons::Location::Addons
-        } else {
-            hemtt_workspace::addons::Location::Optionals
+        let Some(addon) = addon_for(workspace, &source) else {
+            continue;
         };
-        let name = source.as_str().split('/').nth(2).unwrap_or_default();
-        let addon = Arc::new(
-            Addon::new(workspace.root_disk(), name.to_string(), location)
-                .expect("failed to create addon"),
-        );
         for file in source.parent().walk_dir().unwrap_or_default() {
-            if file.extension().unwrap_or_default() == "sqf"
-                && !file.filename().contains(".inc.sqf")
-            {
+            if hemtt_sqf::is_compilation_unit(&file) {
                 futures.spawn(check_sqf(
                     file,
                     addon.clone(),
@@ -145,13 +159,17 @@ async fn check_sqf(
                         }
                     }
                     Err(hemtt_sqf::parser::ParserError::ParsingError(e)) => {
-                        for error in e {
-                            let Some(diag) = error.diagnostic() else {
-                                continue;
-                            };
-                            let diag = diag.to_lsp(&workspace_files);
-                            for (file, diag) in diag {
-                                lsp_diags.entry(file).or_insert_with(Vec::new).push(diag);
+                        if hemtt_sqf::is_cba_settings(processed.as_str()) {
+                            debug!("skipping apparent CBA settings file: {}", source);
+                        } else {
+                            for error in e {
+                                let Some(diag) = error.diagnostic() else {
+                                    continue;
+                                };
+                                let diag = diag.to_lsp(&workspace_files);
+                                for (file, diag) in diag {
+                                    lsp_diags.entry(file).or_insert_with(Vec::new).push(diag);
+                                }
                             }
                         }
                     }
@@ -250,19 +268,10 @@ impl SqfAnalyzer {
                 })
                 .collect::<Vec<_>>();
             drop(files);
-            // `saved` is always its own compilation unit when it's a `.sqf`
-            // file, so it must always be (re)checked directly, even if it
-            // isn't yet a known cache key - e.g. a brand new file from
-            // `didCreateFiles`, the new path of a `didRenameFiles`, or the
-            // first `didSave`/`didOpen` for a file that was never linted
-            // before. `path == &saved` above already covers a previously
-            // tracked file (including one that was just deleted/renamed
-            // away, so it gets recomputed and evicted from the cache).
-            if !recheck.contains(&saved)
-                && std::path::Path::new(&saved.to_string())
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("sqf"))
-            {
+            // `saved` is its own compilation unit, so it is always rechecked
+            // directly, even when it isn't yet a known cache key - a new file,
+            // the new path of a rename, or a first `didOpen`.
+            if !recheck.contains(&saved) && hemtt_sqf::is_compilation_unit(&saved) {
                 recheck.push(saved);
             }
             recheck
@@ -270,22 +279,9 @@ impl SqfAnalyzer {
         let database = self.get_database(&workspace);
         let mut futures = JoinSet::new();
         for path in recheck_files {
-            let addon = Arc::new(
-                Addon::new(
-                    workspace.root_disk(),
-                    path.as_str()
-                        .split('/')
-                        .nth(2)
-                        .unwrap_or_default()
-                        .to_string(),
-                    if path.as_str().starts_with("/addons/") {
-                        hemtt_workspace::addons::Location::Addons
-                    } else {
-                        hemtt_workspace::addons::Location::Optionals
-                    },
-                )
-                .expect("failed to create addon"),
-            );
+            let Some(addon) = addon_for(&workspace, &path) else {
+                continue;
+            };
             futures.spawn(check_sqf(
                 path.clone(),
                 addon,
@@ -304,5 +300,87 @@ impl SqfAnalyzer {
                 warn!("Failed to refresh diagnostics: {:?}", e);
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::WorkspaceFolder;
+    use url::Url;
+
+    use super::addon_for;
+    use crate::workspace::EditorWorkspace;
+
+    /// Open a fixture folder under `hls/tests/fixtures/` as an editor workspace.
+    fn fixture(name: &str) -> EditorWorkspace {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(name);
+        assert!(root.is_dir(), "missing fixture {}", root.display());
+        EditorWorkspace::new(&WorkspaceFolder {
+            uri: Url::from_directory_path(&root).expect("failed to build fixture url"),
+            name: name.to_string(),
+        })
+        .expect("failed to open fixture workspace")
+    }
+
+    #[test]
+    fn addon_in_addons() {
+        let workspace = fixture("project");
+        let path = workspace
+            .root()
+            .join("addons/valid/script.sqf")
+            .expect("join");
+        let addon = addon_for(&workspace, &path).expect("addons/valid is a valid addon");
+        assert_eq!(addon.name(), "valid");
+        assert_eq!(addon.location(), &hemtt_workspace::addons::Location::Addons);
+    }
+
+    #[test]
+    fn addon_missing_prefix() {
+        let workspace = fixture("project");
+        let path = workspace
+            .root()
+            .join("addons/noprefix/script.sqf")
+            .expect("join");
+        assert!(addon_for(&workspace, &path).is_none());
+    }
+
+    #[test]
+    fn no_addon_for_addons_root() {
+        let workspace = fixture("project");
+        let path = workspace.root().join("addons/stray.sqf").expect("join");
+        assert!(addon_for(&workspace, &path).is_none());
+    }
+
+    /// Regression for #1307: a loose `.sqf` in an otherwise complete project.
+    #[test]
+    fn regression_1307_loose_sqf_in_valid_project() {
+        let workspace = fixture("project");
+        for file in ["tools/loose.sqf", "loose.sqf"] {
+            let path = workspace.root().join(file).expect("join");
+            assert!(
+                addon_for(&workspace, &path).is_none(),
+                "{file} should not resolve to an addon"
+            );
+        }
+    }
+
+    /// Regression for #1303: a folder that is not a HEMTT project at all.
+    #[test]
+    fn regression_1303_sqf_without_project() {
+        let workspace = fixture("plain");
+        let path = workspace.root().join("scripts/loose.sqf").expect("join");
+        assert!(addon_for(&workspace, &path).is_none());
+    }
+
+    /// Regression for #1258: the old path of a rename, which no longer exists.
+    #[test]
+    fn regression_1258_renamed_sqf() {
+        let workspace = fixture("plain");
+        let path = workspace.root().join("scripts/gone.sqf").expect("join");
+        assert!(!path.exists().expect("exists"));
+        assert!(addon_for(&workspace, &path).is_none());
     }
 }

--- a/hls/tests/fixtures/plain/scripts/loose.sqf
+++ b/hls/tests/fixtures/plain/scripts/loose.sqf
@@ -1,0 +1,2 @@
+// A .sqf in a folder that is not a HEMTT project at all - see issue #1303
+private _x = 1;

--- a/hls/tests/fixtures/project/.hemtt/project.toml
+++ b/hls/tests/fixtures/project/.hemtt/project.toml
@@ -1,0 +1,3 @@
+name = "Fixture"
+prefix = "fix"
+author = "HEMTT"

--- a/hls/tests/fixtures/project/addons/noprefix/script.sqf
+++ b/hls/tests/fixtures/project/addons/noprefix/script.sqf
@@ -1,0 +1,2 @@
+// This addon folder deliberately has no $PBOPREFIX$
+private _x = 1;

--- a/hls/tests/fixtures/project/addons/valid/$PBOPREFIX$
+++ b/hls/tests/fixtures/project/addons/valid/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\fix\addons\valid

--- a/hls/tests/fixtures/project/addons/valid/script.sqf
+++ b/hls/tests/fixtures/project/addons/valid/script.sqf
@@ -1,0 +1,1 @@
+private _x = 1;

--- a/hls/tests/fixtures/project/tools/loose.sqf
+++ b/hls/tests/fixtures/project/tools/loose.sqf
@@ -1,0 +1,2 @@
+// A .sqf outside of addons/ and optionals/ - it belongs to no addon
+private _x = 1;

--- a/libs/config/src/analyze/lints/c14_unused_external.rs
+++ b/libs/config/src/analyze/lints/c14_unused_external.rs
@@ -1,11 +1,15 @@
 use std::{
-    cell::RefCell, io::Write, path::Path, rc::Rc, sync::{atomic::AtomicU16, Arc, Once, OnceLock}
+    cell::RefCell,
+    io::Write,
+    path::Path,
+    rc::Rc,
+    sync::{atomic::AtomicU16, Arc, Once},
 };
 
 use hemtt_common::config::{LintConfig, ProjectConfig, RuntimeArguments};
 use hemtt_workspace::{
     lint::{AnyLintRunner, Lint, LintRunner},
-    reporting::{Code, Codes, Diagnostic, Processed, Severity},
+    reporting::{Code, Codes, Diagnostic, Mapping, Processed, Severity},
 };
 use indexmap::IndexMap;
 
@@ -90,7 +94,17 @@ impl LintRunner<LintData> for Runner {
         } else {
             None
         };
-        ClassNode::check_unused(&root, &mut Vec::new(), processed, config, &mut file, runtime)
+        // per-run, a long-lived process must not keep counting up forever
+        let count = Arc::new(AtomicU16::new(0));
+        ClassNode::check_unused(
+            &root,
+            &mut Vec::new(),
+            processed,
+            config,
+            &mut file,
+            runtime,
+            &count,
+        )
     }
 }
 struct ClassNode {
@@ -109,35 +123,47 @@ impl ClassNode {
         config: &LintConfig,
         file: &mut Option<fs_err::File>,
         runtime: &hemtt_common::config::RuntimeArguments,
+        count: &Arc<AtomicU16>,
     ) -> Codes {
         let mut codes: Codes = Vec::new();
-        if !cfg.borrow().used && !reported.contains(&cfg.borrow().class) {
+        // a class without a name can't be reported on
+        let unused_name = {
+            let node = cfg.borrow();
+            if node.used || reported.contains(&node.class) {
+                None
+            } else {
+                node.class.name().cloned()
+            }
+        };
+        if let Some(name) = unused_name {
             reported.push(cfg.borrow().class.clone());
             codes.push(Arc::new(CodeC14UnusedExternal::new(
                 cfg.borrow().class.clone(),
+                name.value.clone(),
                 processed,
                 config.severity(),
                 runtime,
+                count,
             )));
-            let name = cfg.borrow().class.name().expect("class has a name").clone();
-            let pos = processed
-                .mapping(name.span.start)
-                .expect("start position exists")
-                .original();
             if let Some(file) = file {
-                writeln!(
-                    file,
-                    "{} - {}:{}:{}",
-                    name.as_str(),
-                    pos.path().as_str().trim_start_matches('/'),
-                    pos.start().1 .0,
-                    pos.start().1 .1 + 1,
-                )
-                .expect("Failed to write to file");
+                // best effort, the list is a convenience
+                if let Some(pos) = processed.mapping(name.span.start).map(Mapping::original)
+                    && let Err(e) = writeln!(
+                        file,
+                        "{} - {}:{}:{}",
+                        name.as_str(),
+                        pos.path().as_str().trim_start_matches('/'),
+                        pos.start().1 .0,
+                        pos.start().1 .1 + 1,
+                    )
+                {
+                    eprintln!("Failed to write to {PATH}: {e}");
+                }
             }
         }
         for subclass in cfg.borrow().subclasses.values() {
-            let inner_codes = Self::check_unused(subclass, reported, processed, config, file, runtime);
+            let inner_codes =
+                Self::check_unused(subclass, reported, processed, config, file, runtime, count);
             codes.extend(inner_codes);
         }
         codes
@@ -300,17 +326,18 @@ impl CodeC14UnusedExternal {
     #[must_use]
     pub fn new(
         class: Class,
+        class_name: String,
         processed: &Processed,
         severity: Severity,
         runtime: &RuntimeArguments,
+        count: &Arc<AtomicU16>,
     ) -> Self {
-        static COUNT: OnceLock<Arc<AtomicU16>> = OnceLock::new();
-        let count = COUNT.get_or_init(|| Arc::new(AtomicU16::new(0))).clone();
+        let count = count.clone();
         let first = count.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0;
         Self {
             severity,
             class,
-            class_name: String::new(),
+            class_name,
             diagnostic: None,
             count,
             first,
@@ -323,11 +350,10 @@ impl CodeC14UnusedExternal {
     }
 
     fn generate_processed(mut self, processed: &Processed) -> Self {
-        let Some(name) = self.class.name() else {
-            panic!("CodeC14UnusedExternal::generate_processed called on class without name");
+        let Some(name) = self.class.name().cloned() else {
+            return self;
         };
-        self.class_name = name.value.clone();
-        self.diagnostic = Diagnostic::from_code_processed(&self, name.span.clone(), processed);
+        self.diagnostic = Diagnostic::from_code_processed(&self, name.span, processed);
         self
     }
 }

--- a/libs/config/tests/lints.rs
+++ b/libs/config/tests/lints.rs
@@ -36,6 +36,8 @@ lint!(c11_file_type);
 lint!(c12_math_could_be_unquoted);
 lint!(c13_config_this_call);
 lint!(c14_unused_external);
+lint!(c14_macro_external);
+lint!(c14_many_unused_external);
 lint!(c15_cfgpatches_scope);
 lint!(c17_extra_semicolon);
 
@@ -64,8 +66,10 @@ fn lint(file: &str) -> (String, ConfigReport) {
             config
                 .codes()
                 .iter()
-                .filter(|e| e.diagnostic().unwrap().code != "L-C16")
-                .map(|e| e.diagnostic().unwrap().to_string(&workspacefiles))
+                // a code may deliberately have no diagnostic
+                .filter_map(|e| e.diagnostic())
+                .filter(|d| d.code != "L-C16")
+                .map(|d| d.to_string(&workspacefiles))
                 .collect::<Vec<_>>()
                 .join("\n")
                 .replace('\r', ""),
@@ -86,6 +90,31 @@ fn lint(file: &str) -> (String, ConfigReport) {
 fn test_c09_magwell_missing_magazine() {
     let (_, report) = lint(stringify!(c09_magwell_missing_magazine));
     insta::assert_compact_debug_snapshot!(report.magazine_well_info());
+}
+
+/// Regression for #1310: C14's summary count is per-run, not per-process.
+#[test]
+fn regression_1310_c14_count_is_per_run() {
+    let first = lint(stringify!(c14_many_unused_external)).0;
+    let second = lint(stringify!(c14_many_unused_external)).0;
+    assert_eq!(first, second);
+    assert!(
+        first.contains("There are 7 unused external classes"),
+        "expected a summary of all 7 unused externals, got:\n{first}"
+    );
+}
+
+/// Regression for #1310: one config's count must not leak into the next.
+#[test]
+fn regression_1310_c14_count_not_shared_between_configs() {
+    let _ = lint(stringify!(c14_many_unused_external));
+    let few = lint(stringify!(c14_macro_external)).0;
+    // under the summary threshold, so each is reported individually
+    assert!(
+        !few.contains("unused external classes"),
+        "expected individual diagnostics, got a summary:\n{few}"
+    );
+    assert_eq!(few.matches("is never used").count(), 3);
 }
 
 #[test]

--- a/libs/config/tests/lints/c14_macro_external.hpp
+++ b/libs/config/tests/lints/c14_macro_external.hpp
@@ -1,0 +1,13 @@
+#define EXTERNAL(NAME) class NAME
+#define QUOTE(var1) #var1
+#define DOUBLES(var1,var2) var1##_##var2
+#define PREFIX cba
+#define EXT_PREFIXED(NAME) class DOUBLES(PREFIX,NAME)
+
+class CfgVehicles {
+    EXTERNAL(alpha);
+    EXT_PREFIXED(beta);
+    class gamma;
+    class used_me;
+    class child: used_me {};
+};

--- a/libs/config/tests/lints/c14_many_unused_external.hpp
+++ b/libs/config/tests/lints/c14_many_unused_external.hpp
@@ -1,0 +1,13 @@
+// More than 5 unused externals, so the lint collapses them into a single
+// summary diagnostic instead of one per class.
+class CfgVehicles {
+    class alpha;
+    class bravo;
+    class charlie;
+    class delta;
+    class echo;
+    class foxtrot;
+    class golf;
+    class used_me;
+    class child: used_me {};
+};

--- a/libs/config/tests/snapshots/lints__config_error_c14_macro_external.snap
+++ b/libs/config/tests/snapshots/lints__config_error_c14_macro_external.snap
@@ -1,0 +1,23 @@
+---
+source: libs/config/tests/lints.rs
+expression: lint(stringify! (c14_macro_external)).0
+---
+[0m[1m[38;5;11mwarning[L-C14][0m[1m: external class alpha is never used[0m
+  [0m[36m┌─[0m c14_macro_external.hpp:8:5
+  [0m[36m│[0m
+[0m[36m8[0m [0m[36m│[0m     [0m[33mEXTERNAL(alpha)[0m;
+  [0m[36m│[0m     [0m[33m^^^^^^^^^^^^^^^[0m [0m[33mnever used[0m
+
+
+[0m[1m[38;5;11mwarning[L-C14][0m[1m: external class cba_beta is never used[0m
+  [0m[36m┌─[0m c14_macro_external.hpp:9:5
+  [0m[36m│[0m
+[0m[36m9[0m [0m[36m│[0m     [0m[33mEXT_PREFIXED(beta)[0m;
+  [0m[36m│[0m     [0m[33m^^^^^^^^^^^^^^^^^^[0m [0m[33mnever used[0m
+
+
+[0m[1m[38;5;11mwarning[L-C14][0m[1m: external class gamma is never used[0m
+   [0m[36m┌─[0m c14_macro_external.hpp:10:11
+   [0m[36m│[0m
+[0m[36m10[0m [0m[36m│[0m     class [0m[33mgamma[0m;
+   [0m[36m│[0m           [0m[33m^^^^^[0m [0m[33mnever used[0m

--- a/libs/config/tests/snapshots/lints__config_error_c14_many_unused_external.snap
+++ b/libs/config/tests/snapshots/lints__config_error_c14_many_unused_external.snap
@@ -1,0 +1,6 @@
+---
+source: libs/config/tests/lints.rs
+expression: lint(stringify! (c14_many_unused_external)).0
+---
+[0m[1m[38;5;11mwarning[L-C14][0m[1m: There are 7 unused external classes[0m
+ [0m[36m=[0m [36mnote[0m: A list has been generated in .hemttout/unused_external_classes.txt, use `hemtt check -Lc14` to output warnings

--- a/libs/sqf/src/lib.rs
+++ b/libs/sqf/src/lib.rs
@@ -14,7 +14,29 @@ use analyze::inspector::Issue;
 use arma3_wiki::model::Version;
 #[doc(no_inline)]
 pub use float_ord::FloatOrd as Scalar;
+use hemtt_workspace::WorkspacePath;
 use parser::database::Database;
+
+#[must_use]
+/// Is this a `.sqf` file that can be compiled and linted on its own?
+///
+/// `.inc.sqf` files rely on the macros of whatever `#include`s them, so they
+/// are never their own compilation unit.
+pub fn is_compilation_unit(path: &WorkspacePath) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("sqf"))
+        && !path.filename().to_ascii_lowercase().ends_with(".inc.sqf")
+}
+
+#[must_use]
+/// Does this preprocessed source look like a CBA settings file?
+///
+/// They use `force` as a statement prefix, which is not valid SQF, so they
+/// never parse and are skipped rather than reported. Takes the preprocessed
+/// output because `force` lines are commonly produced by macros.
+pub fn is_cba_settings(processed: &str) -> bool {
+    processed.starts_with("force ") || processed.contains("\nforce ")
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Statements {
@@ -468,5 +490,76 @@ impl BinaryCommand {
             Self::Associate => ":",
             Self::Select => "#",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hemtt_workspace::{Workspace, WorkspacePath};
+
+    use super::{is_cba_settings, is_compilation_unit};
+
+    /// Build an in-memory workspace holding a single file at `path`.
+    fn path(path: &str) -> WorkspacePath {
+        let workspace = Workspace::builder()
+            .memory()
+            .finish(None, false, &hemtt_common::config::PDriveOption::Disallow)
+            .expect("failed to build workspace");
+        let file = workspace.join(path).expect("failed to join path");
+        file.create_file().expect("failed to create file");
+        file
+    }
+
+    #[test]
+    fn compilation_unit_sqf() {
+        assert!(is_compilation_unit(&path("script.sqf")));
+        assert!(is_compilation_unit(&path("fnc_thing.sqf")));
+        assert!(is_compilation_unit(&path("script.SQF")));
+        assert!(is_compilation_unit(&path("script.Sqf")));
+    }
+
+    #[test]
+    fn compilation_unit_not_sqf() {
+        assert!(!is_compilation_unit(&path("config.cpp")));
+        assert!(!is_compilation_unit(&path("script.hpp")));
+        assert!(!is_compilation_unit(&path("script")));
+        assert!(!is_compilation_unit(&path("script.sqf.bak")));
+    }
+
+    /// Regression for #1308: `.inc.sqf` is not its own compilation unit.
+    #[test]
+    fn regression_1308_include_sqf() {
+        assert!(!is_compilation_unit(&path("initSettings.inc.sqf")));
+        assert!(!is_compilation_unit(&path("thing.INC.SQF")));
+        assert!(!is_compilation_unit(&path("thing.Inc.Sqf")));
+    }
+
+    #[test]
+    fn compilation_unit_inc_not_at_end() {
+        // only `.inc` directly before the extension disqualifies a file
+        assert!(is_compilation_unit(&path("thing.inc.settings.sqf")));
+        assert!(is_compilation_unit(&path("incsqf.sqf")));
+        assert!(is_compilation_unit(&path("my.inc.file.sqf")));
+    }
+
+    /// Regression for #1309: CBA settings files are skipped, not reported.
+    #[test]
+    fn regression_1309_cba_settings_detected() {
+        assert!(is_cba_settings("force ace_medical_level = 2;"));
+        assert!(is_cba_settings(
+            "// a comment\nforce ace_medical_level = 2;"
+        ));
+        assert!(is_cba_settings(
+            "ace_medical_level = 1;\nforce cba_thing = 2;\n"
+        ));
+    }
+
+    #[test]
+    fn cba_settings_not_detected() {
+        assert!(!is_cba_settings(""));
+        assert!(!is_cba_settings("private _x = 1;"));
+        assert!(!is_cba_settings("_unit forceAddUniform \"uniform\";"));
+        assert!(!is_cba_settings("private _f = force _x;"));
+        assert!(!is_cba_settings("    force ace_thing = 1;"));
     }
 }


### PR DESCRIPTION
Fix #1307, fix #1303, fix #1258, fix #1308, fix #1309, fix #1310

Addon resolution is now one `Option`-returning function used by both `check_addons` and `partial_recheck_lints`, instead of two copies that `.expect()`. A `.sqf` outside `addons/`/`optionals/` derived an empty addon name, so `Addon::new` failed with `PrefixMissing` and panicked on `main`, killing the server. Reachable via didOpen (#1303), didRenameFiles (#1258, closed but never fixed) and in valid projects with a loose `.sqf`.

The `.inc.sqf` and CBA settings rules were only in the CLI, or only in one of the HLS's two file-selection paths, so files that build cleanly showed errors in the editor. Both are now single predicates in hemtt_sqf called from the CLI and the HLS.

C14's summary counter was a process-global `static` that never reset, so a language server stopped reporting after the first five unused externals. It is now per-run. Three `.expect()`s in the same lint are removed; `from_code_processed` alongside them already treats the same `Processed` lookup as a legitimate `None`.

The config lint test harness unwrapped `code.diagnostic()`, which panics on any code that deliberately renders nothing.