### PR TITLE
chore: satisfy clippy::assert_is_empty for rust 1.99

### DIFF
--- a/libs/common/src/config/addon/binarize.rs
+++ b/libs/common/src/config/addon/binarize.rs
@@ -78,7 +78,7 @@ exclude = ["test"]
         let file: BinarizeSectionFile = toml::from_str(toml).expect("failed to deserialize");
         let config = BinarizeConfig::from(file);
         assert!(!config.enabled());
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude().as_slice(), [] as [String; 0]);
     }
 
     #[test]
@@ -87,7 +87,7 @@ exclude = ["test"]
         let file: BinarizeSectionFile = toml::from_str(toml).expect("failed to deserialize");
         let config = BinarizeConfig::from(file);
         assert!(config.enabled());
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude().as_slice(), [] as [String; 0]);
     }
 
     #[test]
@@ -96,6 +96,6 @@ exclude = ["test"]
         let file: BinarizeSectionFile = toml::from_str(toml).expect("failed to deserialize");
         let config = BinarizeConfig::from(file);
         assert!(config.enabled());
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude().as_slice(), [] as [String; 0]);
     }
 }

--- a/libs/common/src/config/addon/files.rs
+++ b/libs/common/src/config/addon/files.rs
@@ -56,6 +56,6 @@ exclude = ["test"]
         let toml = "";
         let file: FilesSectionFile = toml::from_str(toml).expect("failed to deserialize");
         let config = FilesConfig::from(file);
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude().as_slice(), [] as [String; 0]);
     }
 }

--- a/libs/common/src/config/addon/mod.rs
+++ b/libs/common/src/config/addon/mod.rs
@@ -189,7 +189,7 @@ exclude = ["test"]
         assert!(config.rapify().enabled());
         assert!(config.binarize().enabled());
         assert!(config.properties().is_empty());
-        assert!(config.files().exclude().is_empty());
+        assert_eq!(config.files().exclude().as_slice(), [] as [String; 0]);
     }
 
     #[test]

--- a/libs/common/src/config/addon/rapify.rs
+++ b/libs/common/src/config/addon/rapify.rs
@@ -63,6 +63,6 @@ exclude = ["test"]
         let file: RapifySectionFile = toml::from_str(toml).expect("failed to deserialize");
         let config = RapifyConfig::from(file);
         assert!(config.enabled());
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude().as_slice(), [] as [String; 0]);
     }
 }

--- a/libs/common/src/config/project/files.rs
+++ b/libs/common/src/config/project/files.rs
@@ -91,6 +91,6 @@ exclude = ["test"]
         let file: FilesSectionFile = toml::from_str(toml).expect("failed to deserialize");
         let config = FilesConfig::from(file);
         assert!(config.include().contains(&"/mod.cpp".to_string()));
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude(), [] as [String; 0]);
     }
 }

--- a/libs/common/src/config/project/hemtt/dev.rs
+++ b/libs/common/src/config/project/hemtt/dev.rs
@@ -49,6 +49,6 @@ exclude = ["test"]
         let toml = "";
         let file: DevOptionsFile = toml::from_str(toml).expect("failed to deserialize");
         let config = DevOptions::from(file);
-        assert!(config.exclude().is_empty());
+        assert_eq!(config.exclude(), [] as [String; 0]);
     }
 }

--- a/libs/common/src/config/project/hemtt/launch.rs
+++ b/libs/common/src/config/project/hemtt/launch.rs
@@ -354,12 +354,12 @@ rapify = false
         let toml = "";
         let file: LaunchOptionsFile = toml::from_str(toml).expect("failed to deserialize");
         let config = LaunchOptions::from(file);
-        assert!(config.workshop().is_empty());
-        assert!(config.dlc().is_empty());
-        assert!(config.presets().is_empty());
-        assert!(config.optionals().is_empty());
+        assert_eq!(config.workshop(), [] as [String; 0]);
+        assert_eq!(config.dlc(), [] as [DLC; 0]);
+        assert_eq!(config.presets(), [] as [String; 0]);
+        assert_eq!(config.optionals(), [] as [String; 0]);
         assert!(config.mission().is_none());
-        assert!(config.parameters().is_empty());
+        assert_eq!(config.parameters(), [] as [String; 0]);
         assert_eq!(config.executable(), "arma3_x64.exe");
         assert!(!config.binarize());
         assert!(config.file_patching());

--- a/libs/preprocessor/src/processor/mod.rs
+++ b/libs/preprocessor/src/processor/mod.rs
@@ -528,7 +528,13 @@ pub mod tests {
             &sources,
         )
         .unwrap();
-        assert!(sources.dependencies_of(root_id).is_empty());
-        assert!(sources.dependents_of(included_id).is_empty());
+        assert_eq!(
+            sources.dependencies_of(root_id),
+            [] as [hemtt_workspace::FileId; 0]
+        );
+        assert_eq!(
+            sources.dependents_of(included_id),
+            [] as [hemtt_workspace::FileId; 0]
+        );
     }
 }

--- a/libs/workspace/src/source.rs
+++ b/libs/workspace/src/source.rs
@@ -491,8 +491,8 @@ mod tests {
 
         assert_eq!(db.dependencies_of(root_id), vec![included_id]);
         assert_eq!(db.dependents_of(included_id), vec![root_id]);
-        assert!(db.dependencies_of(included_id).is_empty());
-        assert!(db.dependents_of(root_id).is_empty());
+        assert_eq!(db.dependencies_of(included_id), [] as [FileId; 0]);
+        assert_eq!(db.dependents_of(root_id), [] as [FileId; 0]);
     }
 
     #[test]
@@ -536,7 +536,7 @@ mod tests {
         db.record_dependency(root_id, included_id);
         db.clear_dependencies_of(root_id);
 
-        assert!(db.dependencies_of(root_id).is_empty());
-        assert!(db.dependents_of(included_id).is_empty());
+        assert_eq!(db.dependencies_of(root_id), [] as [FileId; 0]);
+        assert_eq!(db.dependents_of(included_id), [] as [FileId; 0]);
     }
 }


### PR DESCRIPTION
New pedantic lint in 1.99-beta, 19 sites, all in tests. `assert_eq!` against an empty array prints the offending value on failure where `assert!(x.is_empty())` printed nothing.

Clippy's own suggestion (`assert_eq!(x.as_slice(), [])`) does not compile - the empty array literal has no inferrable element type - so the type is spelled out.

Clean on both stable 1.98 and beta 1.99.