### PR TITLE
hls: Show return type for commands

### DIFF
--- a/hls/src/sqf/hover.rs
+++ b/hls/src/sqf/hover.rs
@@ -285,6 +285,18 @@ fn markdown_syntax(command: &Command, syntax: &Syntax) -> String {
         )
         .expect("Failed to write to string");
     }
+    let (typ, _info) = syntax.ret();
+    let typ = typ.to_string();
+    let typ = if typ == "Unknown" {
+        typ
+    } else {
+        format!(
+            "[{}](https://community.bistudio.com/wiki/{})",
+            typ,
+            typ.replace(' ', "_")
+        )
+    };
+    writeln!(string, "\nReturns: {typ}").expect("Failed to write to string");
     string
 }
 


### PR DESCRIPTION
<img width="337" height="305" alt="image" src="https://github.com/user-attachments/assets/d718906c-f5cf-4981-a6a0-e669ec77a15b" />
